### PR TITLE
Aanpassen SKOS notatie voor codelijsten

### DIFF
--- a/cms/openbaardomein/index.html
+++ b/cms/openbaardomein/index.html
@@ -315,6 +315,15 @@
               			<!--end grid-->					    
 					<!-- end applicatieprofielen -->	
 					<h2 id="standaarden_in_ontwikkeling" class="h1">Vragen en feedback</h1>	
+            <div class="alert alert--warning">
+              <div class="alert__icon" aria-hidden="true"></div>
+              <div class="alert__content">
+                <div class="alert__title">Publieke reviewperiode</div>
+                <div class="alert__message">
+                  <p>De publieke reviewperiode van deze kandidaat-standaard loopt tot 25 september 2018.</p>
+                </div>
+              </div>
+            </div>
 				    <div class="col--1-1 u-spacer--large">
 				    	<p>In geval van vragen of feedback kan u contact opnemen <a href="mailto:informatie.vlaanderen@vlaanderen.be">via e-mail</a> of een topic aanmaken in onze publieke <a href="https://github.com/Informatievlaanderen/OSLO-Public-Discussion" title="GitHub issue-tracker">GitHub issue-tracker</a>.</p>
 				    </div>			  

--- a/doc/conceptscheme/BoomvormconditieKlassen.ttl
+++ b/doc/conceptscheme/BoomvormconditieKlassen.ttl
@@ -1,36 +1,40 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen>
+<https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen>
    a skos:ConceptScheme ;
-   skos:definition "TODO"@nl ;
-   rdfs:label "BoomvormconditieKlassen"@nl .
+   skos:definition "De conditie beoordeeld volgens de kronenstructuur van Dr. A. Roloff, gelet op de scheutlengte ontwikkeling en vorming van dood hout."@nl ;
+   skos:prefLabel "Boomvormconditie Klassen"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#0>
+<https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/0>
    a skos:Concept ;
-   rdfs:label "0"@nl ;
+   skos:prefLabel "Goed"@nl ;
    skos:definition "De conditie is goed. Op middellange termijn (10 tot 15 jaar) worden geen problemen verwacht."@nl ;
    skos:notation "0"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#1>
+<https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/1>
    a skos:Concept ;
-   rdfs:label "1"@nl ;
+   skos:prefLabel "Matig"@nl ;
    skos:definition "De conditie is verminderd, maar op korte termijn (< 5 jaar) worden ten aanzien van de fysiologische toestand van de boom geen problemen verwacht."@nl ;
    skos:notation "1"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#2>
+<https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/2>
    a skos:Concept ;
-   rdfs:label "2"@nl ;
+   skos:prefLabel "Slecht"@nl ;
    skos:definition "De conditie is duidelijk verminderd. De fysiologische toestand van de boom is slecht, maar herstel van de boom is eventueel mogelijk."@nl ;
    skos:notation "2"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#3>
+<https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/3>
    a skos:Concept ;
-   rdfs:label "3"@nl ;
-   skos:definition "De conditie en toekomstverwachting van de boom is minimaal. De mechanische en/of fysiologische toestand van de boom is dusdanig slecht dat herstel van de boom niet of nauwelijks mogelijk is."@nl ;
+   skos:prefLabel "Zeer slecht"@nl ;
+   skos:definition "De conditie en toekomstverwachting van de boom is minimaal. De mechanische en/of fysiologische toestand van de boom is dusdanig slecht dat 'herstel' van de boom niet of nauwelijks mogelijk is."@nl ;
    skos:notation "3"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen> .
 

--- a/doc/conceptscheme/BoomvormconditieKlassen.ttl
+++ b/doc/conceptscheme/BoomvormconditieKlassen.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "De conditie beoordeeld volgens de kronenstructuur van Dr. A. Roloff, gelet op de scheutlengte ontwikkeling en vorming van dood hout."@nl ;
    skos:prefLabel "Boomvormconditie Klassen"@nl .
 

--- a/doc/conceptscheme/BoomvormconditieKlassen/index.html
+++ b/doc/conceptscheme/BoomvormconditieKlassen/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-06-01</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -55,10 +55,10 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id=""><a href="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen" data-placement="right"></a></h3>
+              <h3 class="h3" id="Boomvormconditie Klassen"><a href="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen" data-placement="right">Boomvormconditie Klassen</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
-                    <dt>Beschrijving</dt><dd>TODO</dd>
+                    <dt>Beschrijving</dt><dd>De conditie beoordeeld volgens de kronenstructuur van Dr. A. Roloff, gelet op de scheutlengte ontwikkeling en vorming van dood hout.</dd>
                     
                   </dl>
                 </div>
@@ -76,22 +76,10 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="%3A" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#3">
+                      <tr id="Boomvormconditie%20Klassen%3AGoed" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/0">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#3" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#3" data-placement="right">
-                            </a>
-                          </code>
-                        </td>
-                        <td property="skos:definition">De conditie en toekomstverwachting van de boom is minimaal. De mechanische en/of fysiologische toestand van de boom is dusdanig slecht dat &#194;&#8216;herstel&#194;&#8217; van de boom niet of nauwelijks mogelijk is.</td>
-                        <td property="skos:note"></td>
-                        <td property="skos:note">3</td>
-                      </tr>
-                    
-                      <tr id="%3AGoed" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#0">
-                        <td>
-                          <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#0" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#0" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/0" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/0" data-placement="right">
                             Goed</a>
                           </code>
                         </td>
@@ -100,10 +88,10 @@
                         <td property="skos:note">0</td>
                       </tr>
                     
-                      <tr id="%3AMatig" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#1">
+                      <tr id="Boomvormconditie%20Klassen%3AMatig" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/1">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#1" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#1" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/1" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/1" data-placement="right">
                             Matig</a>
                           </code>
                         </td>
@@ -112,16 +100,28 @@
                         <td property="skos:note">1</td>
                       </tr>
                     
-                      <tr id="%3ASlecht" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#2">
+                      <tr id="Boomvormconditie%20Klassen%3ASlecht" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/2">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#2" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen#2" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/2" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/2" data-placement="right">
                             Slecht</a>
                           </code>
                         </td>
                         <td property="skos:definition">De conditie is duidelijk verminderd. De fysiologische toestand van de boom is slecht, maar herstel van de boom is eventueel mogelijk.</td>
                         <td property="skos:note"></td>
                         <td property="skos:note">2</td>
+                      </tr>
+                    
+                      <tr id="Boomvormconditie%20Klassen%3AZeer%20slecht" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/3">
+                        <td>
+                          <code property="rdfs:label">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/3" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/BoomvormconditieKlassen/3" data-placement="right">
+                            Zeer slecht</a>
+                          </code>
+                        </td>
+                        <td property="skos:definition">De conditie en toekomstverwachting van de boom is minimaal. De mechanische en/of fysiologische toestand van de boom is dusdanig slecht dat 'herstel' van de boom niet of nauwelijks mogelijk is.</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">3</td>
                       </tr>
                     
                     </tbody>

--- a/doc/conceptscheme/Contactkanaal.ttl
+++ b/doc/conceptscheme/Contactkanaal.ttl
@@ -1,29 +1,32 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Contactkanaal>
+<https://data.vlaanderen.be/id/conceptscheme/Contactkanaal>
    a skos:ConceptScheme ;
    skos:definition "Het technisch medium waarlangs het notificatie wordt verzonden."@nl ;
-   rdfs:label "Contactkanaal"@nl .
+   skos:prefLabel "Notificatiekanaal"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Passief>
+<https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Passief>
    a skos:Concept ;
-   rdfs:label "Passief"@nl ;
+   skos:prefLabel "Passief"@nl ;
    skos:definition "Passieve notificaties worden enkel getoond binnen een bepaalde toestemming na authenticatie van de gebruiker."@nl ;
    skos:notation "Passief"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Contactkanaal> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Contactkanaal> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Contactkanaal> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Sms>
+<https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Sms>
    a skos:Concept ;
-   rdfs:label "Sms"@nl ;
+   skos:prefLabel "SMS"@nl ;
    skos:definition "Contact via tekstberichten die via sms naar een telefoonnummer verzonden worden."@nl ;
    skos:notation "Sms"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Contactkanaal> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Contactkanaal> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Contactkanaal> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Email>
+<https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Email>
    a skos:Concept ;
-   rdfs:label "Email"@nl ;
+   skos:prefLabel "E-mail"@nl ;
    skos:definition "Contact via e-mail."@nl ;
    skos:notation "Email"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Contactkanaal> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Contactkanaal> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Contactkanaal> .
 

--- a/doc/conceptscheme/Contactkanaal.ttl
+++ b/doc/conceptscheme/Contactkanaal.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Contactkanaal>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Het technisch medium waarlangs het notificatie wordt verzonden."@nl ;
    skos:prefLabel "Notificatiekanaal"@nl .
 

--- a/doc/conceptscheme/Contactkanaal/index.html
+++ b/doc/conceptscheme/Contactkanaal/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-06-15</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -55,7 +55,7 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id="Notificatiekanaal"><a href="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal" data-placement="right">Notificatiekanaal</a></h3>
+              <h3 class="h3" id="Notificatiekanaal"><a href="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal" data-placement="right">Notificatiekanaal</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
                     <dt>Beschrijving</dt><dd>Het technisch medium waarlangs het notificatie wordt verzonden.</dd>
@@ -76,10 +76,10 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="Notificatiekanaal%3AE-mail" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Email">
+                      <tr id="Notificatiekanaal%3AE-mail" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Email">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Email" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Email" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Email" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Email" data-placement="right">
                             E-mail</a>
                           </code>
                         </td>
@@ -88,10 +88,10 @@
                         <td property="skos:note">Email</td>
                       </tr>
                     
-                      <tr id="Notificatiekanaal%3APassief" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Passief">
+                      <tr id="Notificatiekanaal%3APassief" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Passief">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Passief" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Passief" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Passief" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Passief" data-placement="right">
                             Passief</a>
                           </code>
                         </td>
@@ -100,10 +100,10 @@
                         <td property="skos:note">Passief</td>
                       </tr>
                     
-                      <tr id="Notificatiekanaal%3ASMS" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Sms">
+                      <tr id="Notificatiekanaal%3ASMS" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Sms">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Sms" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Contactkanaal#Sms" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Sms" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Sms" data-placement="right">
                             SMS</a>
                           </code>
                         </td>

--- a/doc/conceptscheme/DekselVorm.ttl
+++ b/doc/conceptscheme/DekselVorm.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/DekselVorm>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "De vorm van het deksel."@nl ;
    skos:prefLabel "Dekselvorm"@nl .
 

--- a/doc/conceptscheme/DekselVorm.ttl
+++ b/doc/conceptscheme/DekselVorm.ttl
@@ -1,22 +1,24 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/DekselVorm>
+<https://data.vlaanderen.be/id/conceptscheme/DekselVorm>
    a skos:ConceptScheme ;
    skos:definition "De vorm van het deksel."@nl ;
-   rdfs:label "DekselVorm"@nl .
+   skos:prefLabel "Dekselvorm"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/DekselVorm#VIERKANT>
+<https://data.vlaanderen.be/id/conceptscheme/DekselVorm/VIERKANT>
    a skos:Concept ;
-   rdfs:label "VIERKANT"@nl ;
+   skos:prefLabel "Vierkant"@nl ;
    skos:definition "Het deksel is vierkant."@nl ;
    skos:notation "VIERKANT"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/DekselVorm> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/DekselVorm> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/DekselVorm> .
 
-<http://data.vlaanderen.be/id/conceptscheme/DekselVorm#CIRKELVORMIG>
+<https://data.vlaanderen.be/id/conceptscheme/DekselVorm/CIRKELVORMIG>
    a skos:Concept ;
-   rdfs:label "CIRKELVORMIG"@nl ;
+   skos:prefLabel "Cirkelvormig"@nl ;
    skos:definition "Het deksel is cirkelvormig."@nl ;
    skos:notation "CIRKELVORMIG"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/DekselVorm> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/DekselVorm> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/DekselVorm> .
 

--- a/doc/conceptscheme/DekselVorm/index.html
+++ b/doc/conceptscheme/DekselVorm/index.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="nl" lang="nl" dir="ltr" typeof="bibo:Document " about="" property="dcterms:language" content="nl" prefix="dcterms: http://purl.org/dc/terms/ bibo: http://purl.org/ontology/bibo/ schema: http://schema.org/ w3p: http://www.w3.org/2001/02pd/rec54#">
 
 <head>
-  <title>Vervoersmiddelen</title>
+  <title>DekselVorm</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -36,7 +36,7 @@
         <div class="layout layout--wide">
           <div class="grid u-hr">
             <div class="col--9-12 col--1-1--s">
-              <h1 class="h1">Codelijst: Vervoersmiddelen</h1>
+              <h1 class="h1">Codelijst: DekselVorm</h1>
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
@@ -55,10 +55,10 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id="Vervoersmiddelen"><a href="https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen" data-placement="right">Vervoersmiddelen</a></h3>
+              <h3 class="h3" id="Dekselvorm"><a href="https://data.vlaanderen.be/id/conceptscheme/DekselVorm" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/DekselVorm" data-placement="right">Dekselvorm</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
-                    <dt>Beschrijving</dt><dd>Types vervoersmidellen</dd>
+                    <dt>Beschrijving</dt><dd>De vorm van het deksel.</dd>
                     
                   </dl>
                 </div>
@@ -76,28 +76,28 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="Vervoersmiddelen%3AAuto" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen/Auto">
+                      <tr id="Dekselvorm%3ACirkelvormig" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/DekselVorm/CIRKELVORMIG">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen/Auto" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen/Auto" data-placement="right">
-                            Auto</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/DekselVorm/CIRKELVORMIG" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/DekselVorm/CIRKELVORMIG" data-placement="right">
+                            Cirkelvormig</a>
                           </code>
                         </td>
-                        <td property="skos:definition">TODO</td>
+                        <td property="skos:definition">Het deksel is cirkelvormig.</td>
                         <td property="skos:note"></td>
-                        <td property="skos:note">Auto</td>
+                        <td property="skos:note">CIRKELVORMIG</td>
                       </tr>
                     
-                      <tr id="Vervoersmiddelen%3AFiets" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen/Fiets">
+                      <tr id="Dekselvorm%3AVierkant" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/DekselVorm/VIERKANT">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen/Fiets" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen/Fiets" data-placement="right">
-                            Fiets</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/DekselVorm/VIERKANT" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/DekselVorm/VIERKANT" data-placement="right">
+                            Vierkant</a>
                           </code>
                         </td>
-                        <td property="skos:definition">TODO</td>
+                        <td property="skos:definition">Het deksel is vierkant.</td>
                         <td property="skos:note"></td>
-                        <td property="skos:note">Fiets</td>
+                        <td property="skos:note">VIERKANT</td>
                       </tr>
                     
                     </tbody>

--- a/doc/conceptscheme/DrassigheidWaarde.ttl
+++ b/doc/conceptscheme/DrassigheidWaarde.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "TODO"@nl ;
    skos:prefLabel ""@nl .
 

--- a/doc/conceptscheme/DrassigheidWaarde.ttl
+++ b/doc/conceptscheme/DrassigheidWaarde.ttl
@@ -1,29 +1,32 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde>
+<https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde>
    a skos:ConceptScheme ;
    skos:definition "TODO"@nl ;
-   rdfs:label "DrassigheidWaarde"@nl .
+   skos:prefLabel ""@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#NIET_DRASSIG>
+<https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/NIET_DRASSIG>
    a skos:Concept ;
-   rdfs:label "NIET_DRASSIG"@nl ;
+   skos:prefLabel ""@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "NIET_DRASSIG"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde> .
 
-<http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#MATIG_DRASSIG>
+<https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/MATIG_DRASSIG>
    a skos:Concept ;
-   rdfs:label "MATIG_DRASSIG"@nl ;
+   skos:prefLabel ""@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "MATIG_DRASSIG"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde> .
 
-<http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#STERK_DRASSIG>
+<https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/STERK_DRASSIG>
    a skos:Concept ;
-   rdfs:label "STERK_DRASSIG"@nl ;
+   skos:prefLabel ""@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "STERK_DRASSIG"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde> .
 

--- a/doc/conceptscheme/DrassigheidWaarde/index.html
+++ b/doc/conceptscheme/DrassigheidWaarde/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-06-01</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -55,7 +55,7 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id=""><a href="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde" data-placement="right"></a></h3>
+              <h3 class="h3" id=""><a href="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde" data-placement="right"></a></h3>
                 <div class="region region--no-space-top">
                   <dl>
                     <dt>Beschrijving</dt><dd>TODO</dd>
@@ -76,10 +76,10 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="%3A" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#NIET_DRASSIG">
+                      <tr id="%3A" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/NIET_DRASSIG">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#NIET_DRASSIG" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#NIET_DRASSIG" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/NIET_DRASSIG" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/NIET_DRASSIG" data-placement="right">
                             </a>
                           </code>
                         </td>
@@ -88,10 +88,10 @@
                         <td property="skos:note">NIET_DRASSIG</td>
                       </tr>
                     
-                      <tr id="%3A" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#MATIG_DRASSIG">
+                      <tr id="%3A" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/MATIG_DRASSIG">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#MATIG_DRASSIG" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#MATIG_DRASSIG" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/MATIG_DRASSIG" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/MATIG_DRASSIG" data-placement="right">
                             </a>
                           </code>
                         </td>
@@ -100,10 +100,10 @@
                         <td property="skos:note">MATIG_DRASSIG</td>
                       </tr>
                     
-                      <tr id="%3A" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#STERK_DRASSIG">
+                      <tr id="%3A" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/STERK_DRASSIG">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#STERK_DRASSIG" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde#STERK_DRASSIG" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/STERK_DRASSIG" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/DrassigheidWaarde/STERK_DRASSIG" data-placement="right">
                             </a>
                           </code>
                         </td>

--- a/doc/conceptscheme/Graftypes.ttl
+++ b/doc/conceptscheme/Graftypes.ttl
@@ -1,3 +1,4 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 

--- a/doc/conceptscheme/Graftypes/index.html
+++ b/doc/conceptscheme/Graftypes/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-06-01</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -53,70 +53,6 @@
         <div class="grid">
           <div>
             
-            
-            <div class="region region--no-space-top">
-              <h3 class="h3" id="Graftypes"><a href="http://data.vlaanderen.be/id/conceptscheme/Graftypes" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Graftypes" data-placement="right">Graftypes</a></h3>
-                <div class="region region--no-space-top">
-                  <dl>
-                    <dt>Beschrijving</dt><dd>Types graven.</dd>
-                    
-                  </dl>
-                </div>
-                
-                <div class="u-table-overflow">
-                  <table class="data-table">
-                    <thead>
-                      <tr class="data-table__header">
-                        <th class="data-table__header-title--sortable data-table__header-title--sortable-active">Label</th>
-                        <th class="data-table__header-title--sortable">Definitie</th>
-                        <th class="data-table__header-title--sortable">Notitie</th>
-                        <th class="data-table__header-title--sortable">Notatie</th>
-                      </tr>
-                    </thead>
-        
-                    <tbody class="supertype">
-                    
-                      <tr id="Graftypes%3AEcologisch%20graf" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Graftypes#EcologischGraf">
-                        <td>
-                          <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Graftypes#EcologischGraf" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Graftypes#EcologischGraf" data-placement="right">
-                            Ecologisch graf</a>
-                          </code>
-                        </td>
-                        <td property="skos:definition">Een milieuvriendelijk graf in een gebied waar de natuur zo veel mogelijk haar gang mag gaan.</td>
-                        <td property="skos:note"></td>
-                        <td property="skos:note">EcologischGraf</td>
-                      </tr>
-                    
-                      <tr id="Graftypes%3AKlassiek%20graf" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Graftypes#KlassiekGraf">
-                        <td>
-                          <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Graftypes#KlassiekGraf" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Graftypes#KlassiekGraf" data-placement="right">
-                            Klassiek graf</a>
-                          </code>
-                        </td>
-                        <td property="skos:definition">Een graf waar lijken in begraven worden.</td>
-                        <td property="skos:note"></td>
-                        <td property="skos:note">KlassiekGraf</td>
-                      </tr>
-                    
-                      <tr id="Graftypes%3ANisgraf" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Graftypes#Nisgraf">
-                        <td>
-                          <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Graftypes#Nisgraf" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Graftypes#Nisgraf" data-placement="right">
-                            Nisgraf</a>
-                          </code>
-                        </td>
-                        <td property="skos:definition">Een uitsparing in de dikte van een muur voor het plaatsen van een urne met assen van overledenen.</td>
-                        <td property="skos:note"></td>
-                        <td property="skos:note">Nisgraf</td>
-                      </tr>
-                    
-                    </tbody>
-                  </table>
-                </div>
-      			  
-            </div>
             
 
           </div>         

--- a/doc/conceptscheme/Groeifasen.ttl
+++ b/doc/conceptscheme/Groeifasen.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Groeifasen>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "De levensfase van een boom. De mogelijke types zijn gedefinieerd door Inverde."@nl ;
    skos:prefLabel "Groeifasen"@nl .
 

--- a/doc/conceptscheme/Groeifasen.ttl
+++ b/doc/conceptscheme/Groeifasen.ttl
@@ -1,43 +1,48 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Groeifasen>
+<https://data.vlaanderen.be/id/conceptscheme/Groeifasen>
    a skos:ConceptScheme ;
    skos:definition "De levensfase van een boom. De mogelijke types zijn gedefinieerd door Inverde."@nl ;
-   rdfs:label "Groeifasen"@nl .
+   skos:prefLabel "Groeifasen"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Aanslagfase>
+<https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Aanslagfase>
    a skos:Concept ;
-   rdfs:label "Aanslagfase"@nl ;
+   skos:prefLabel "Aanslagfase"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Aanslagfase"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Groeifasen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Groeifasen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Groeifasen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Jeugd>
+<https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Jeugd>
    a skos:Concept ;
-   rdfs:label "Jeugd"@nl ;
+   skos:prefLabel "Jeugd"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Jeugd"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Groeifasen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Groeifasen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Groeifasen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Volwassen>
+<https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Volwassen>
    a skos:Concept ;
-   rdfs:label "Volwassen"@nl ;
+   skos:prefLabel "Volwassen"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Volwassen"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Groeifasen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Groeifasen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Groeifasen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Aftakeling>
+<https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Aftakeling>
    a skos:Concept ;
-   rdfs:label "Aftakeling"@nl ;
+   skos:prefLabel "Aftakeling"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Aftakeling"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Groeifasen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Groeifasen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Groeifasen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Dood>
+<https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Dood>
    a skos:Concept ;
-   rdfs:label "Dood"@nl ;
+   skos:prefLabel "Dood"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Dood"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Groeifasen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Groeifasen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Groeifasen> .
 

--- a/doc/conceptscheme/Groeifasen/index.html
+++ b/doc/conceptscheme/Groeifasen/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-06-01</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -55,10 +55,10 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id=""><a href="http://data.vlaanderen.be/id/conceptscheme/Groeifasen" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Groeifasen" data-placement="right"></a></h3>
+              <h3 class="h3" id="Groeifasen"><a href="https://data.vlaanderen.be/id/conceptscheme/Groeifasen" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Groeifasen" data-placement="right">Groeifasen</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
-                    <dt>Beschrijving</dt><dd>TODO</dd>
+                    <dt>Beschrijving</dt><dd>De levensfase van een boom. De mogelijke types zijn gedefinieerd door Inverde.</dd>
                     
                   </dl>
                 </div>
@@ -76,11 +76,11 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="%3A" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Aanslagfase">
+                      <tr id="Groeifasen%3AAanslagfase" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Aanslagfase">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Aanslagfase" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Aanslagfase" data-placement="right">
-                            </a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Aanslagfase" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Aanslagfase" data-placement="right">
+                            Aanslagfase</a>
                           </code>
                         </td>
                         <td property="skos:definition">TODO</td>
@@ -88,35 +88,11 @@
                         <td property="skos:note">Aanslagfase</td>
                       </tr>
                     
-                      <tr id="%3A" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Jeugd">
+                      <tr id="Groeifasen%3AAftakeling" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Aftakeling">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Jeugd" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Jeugd" data-placement="right">
-                            </a>
-                          </code>
-                        </td>
-                        <td property="skos:definition">TODO</td>
-                        <td property="skos:note"></td>
-                        <td property="skos:note">Jeugd</td>
-                      </tr>
-                    
-                      <tr id="%3A" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Volwassen">
-                        <td>
-                          <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Volwassen" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Volwassen" data-placement="right">
-                            </a>
-                          </code>
-                        </td>
-                        <td property="skos:definition">TODO</td>
-                        <td property="skos:note"></td>
-                        <td property="skos:note">Volwassen</td>
-                      </tr>
-                    
-                      <tr id="%3A" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Aftakeling">
-                        <td>
-                          <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Aftakeling" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Aftakeling" data-placement="right">
-                            </a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Aftakeling" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Aftakeling" data-placement="right">
+                            Aftakeling</a>
                           </code>
                         </td>
                         <td property="skos:definition">TODO</td>
@@ -124,16 +100,40 @@
                         <td property="skos:note">Aftakeling</td>
                       </tr>
                     
-                      <tr id="%3A" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Dood">
+                      <tr id="Groeifasen%3ADood" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Dood">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Dood" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Groeifasen#Dood" data-placement="right">
-                            </a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Dood" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Dood" data-placement="right">
+                            Dood</a>
                           </code>
                         </td>
                         <td property="skos:definition">TODO</td>
                         <td property="skos:note"></td>
                         <td property="skos:note">Dood</td>
+                      </tr>
+                    
+                      <tr id="Groeifasen%3AJeugd" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Jeugd">
+                        <td>
+                          <code property="rdfs:label">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Jeugd" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Jeugd" data-placement="right">
+                            Jeugd</a>
+                          </code>
+                        </td>
+                        <td property="skos:definition">TODO</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">Jeugd</td>
+                      </tr>
+                    
+                      <tr id="Groeifasen%3AVolwassen" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Volwassen">
+                        <td>
+                          <code property="rdfs:label">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Volwassen" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Groeifasen/Volwassen" data-placement="right">
+                            Volwassen</a>
+                          </code>
+                        </td>
+                        <td property="skos:definition">TODO</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">Volwassen</td>
                       </tr>
                     
                     </tbody>

--- a/doc/conceptscheme/Nauwkeurigsheidsklassen.ttl
+++ b/doc/conceptscheme/Nauwkeurigsheidsklassen.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "De nauwkeurigheid waarmee objecten opgemeten worden hangt af van de meetmethode (terrestrisch of via luchtfotogrammetrie) en van de precisie waarmee objecten op het terrein kunnen aangeduid worden. Het GRB definieert 6 nauwkeurigheidsklassen van A tot en met F. Daarnaast werden op basis van het IMKL datamodel ook nog de waarden 'tot 50cm' en 'tot 100cm' opgenomen."@nl ;
    skos:prefLabel "Nauwkeurigheidsklassen"@nl .
 

--- a/doc/conceptscheme/Nauwkeurigsheidsklassen.ttl
+++ b/doc/conceptscheme/Nauwkeurigsheidsklassen.ttl
@@ -1,65 +1,73 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen>
+<https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen>
    a skos:ConceptScheme ;
-   skos:definition "De nauwkeurigheid waarmee objecten opgemeten worden hangt af van de meetmethode (terrestrisch of via luchtfotogrammetrie) en van de precisie waarmee objecten op het terrein kunnen aangeduid worden. Het GRB definieert 6 nauwkeurigheidsklassen van A tot en met F. Daarnaast werden op basis van het IMKL datamodel ook nog de waarden 'tot 50cm' en tot 100cm' opgenomen."@nl ;
-   rdfs:label "Nauwkeurigsheidsklassen"@nl .
+   skos:definition "De nauwkeurigheid waarmee objecten opgemeten worden hangt af van de meetmethode (terrestrisch of via luchtfotogrammetrie) en van de precisie waarmee objecten op het terrein kunnen aangeduid worden. Het GRB definieert 6 nauwkeurigheidsklassen van A tot en met F. Daarnaast werden op basis van het IMKL datamodel ook nog de waarden 'tot 50cm' en 'tot 100cm' opgenomen."@nl ;
+   skos:prefLabel "Nauwkeurigheidsklassen"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen#A>
+<https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/A>
    a skos:Concept ;
-   rdfs:label "A"@nl ;
+   skos:prefLabel "Klasse A"@nl ;
    skos:definition "Idealisatienauwkeurigheid van 0,7cm en een relatieve nauwkeurigheid van 4cm."@nl ;
    skos:notation "A"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen#B>
+<https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/B>
    a skos:Concept ;
-   rdfs:label "B"@nl ;
+   skos:prefLabel "Klasse B"@nl ;
    skos:definition "Idealisatienauwkeurigheid van 2cm en een relatieve nauwkeurigheid van 5cm."@nl ;
    skos:notation "B"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen#C>
+<https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/C>
    a skos:Concept ;
-   rdfs:label "C"@nl ;
+   skos:prefLabel "Klasse C"@nl ;
    skos:definition "Idealisatienauwkeurigheid van 4cm en een relatieve nauwkeurigheid van 7cm."@nl ;
    skos:notation "C"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen#D>
+<https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/D>
    a skos:Concept ;
-   rdfs:label "D"@nl ;
+   skos:prefLabel "Klasse D"@nl ;
    skos:definition "Idealisatienauwkeurigheid van 15cm en een relatieve nauwkeurigheid van 15cm."@nl ;
    skos:notation "D"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen#E>
+<https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/E>
    a skos:Concept ;
-   rdfs:label "E"@nl ;
+   skos:prefLabel "Klasse E"@nl ;
    skos:definition "Idealisatienauwkeurigheid van 20cm en een relatieve nauwkeurigheid van 30cm."@nl ;
    skos:notation "E"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen#F>
+<https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/F>
    a skos:Concept ;
-   rdfs:label "F"@nl ;
+   skos:prefLabel "Klasse F"@nl ;
    skos:definition "Geen nauwkeurigheidsinformatie beschikbaar."@nl ;
    skos:notation "F"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen#tot50cm>
+<https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/tot50cm>
    a skos:Concept ;
-   rdfs:label "tot50cm"@nl ;
+   skos:prefLabel "Tot 50 cm"@nl ;
    skos:definition "Nauwkeurigheidsgraad tot op 50 cm."@nl ;
    skos:notation "tot50cm"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen#tot100cm>
+<https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/tot100cm>
    a skos:Concept ;
-   rdfs:label "tot100cm"@nl ;
+   skos:prefLabel "Tot 100 cm"@nl ;
    skos:definition "Nauwkeurigheidsgraad tot op 100 cm.
 "@nl ;
    skos:notation "tot100cm"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen> .
 

--- a/doc/conceptscheme/Notificatiecategorie.ttl
+++ b/doc/conceptscheme/Notificatiecategorie.ttl
@@ -4,61 +4,69 @@
 <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie>
    a skos:ConceptScheme ;
    skos:definition "De categorie van de notificatie"@nl ;
-   rdfs:label "Notificatiecategorie"@nl .
+   skos:prefLabel "NotificatieCategorie"@nl .
 
 <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie/Wetswijziging>
    a skos:Concept ;
-   rdfs:label "Wetswijziging"@nl ;
+   skos:prefLabel "Wetswijziging"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Wetswijziging"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie/NieuweSubsidiemaatregel>
    a skos:Concept ;
-   rdfs:label "NieuweSubsidiemaatregel"@nl ;
+   skos:prefLabel "Nieuwe subsidiemaatregel"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "NieuweSubsidiemaatregel"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie/AlgemeenNieuwsbericht>
    a skos:Concept ;
-   rdfs:label "AlgemeenNieuwsbericht"@nl ;
+   skos:prefLabel "Algemeen nieuwsbericht"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "AlgemeenNieuwsbericht"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie/WijzigingDossier>
    a skos:Concept ;
-   rdfs:label "WijzigingDossier"@nl ;
+   skos:prefLabel "Wijziging Dossier"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "WijzigingDossier"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie/VergunningVerloopt>
    a skos:Concept ;
-   rdfs:label "VergunningVerloopt"@nl ;
+   skos:prefLabel "Vergunning verloopt"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "VergunningVerloopt"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie/ActieNodig>
    a skos:Concept ;
-   rdfs:label "ActieNodig"@nl ;
+   skos:prefLabel "Actie nodig"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "ActieNodig"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie/CalamiteitInUwGemeente>
    a skos:Concept ;
-   rdfs:label "CalamiteitInUwGemeente"@nl ;
+   skos:prefLabel "Calamiteit in uw gemeente"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "CalamiteitInUwGemeente"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie/WegenwerkenInUwBuurt>
    a skos:Concept ;
-   rdfs:label "WegenwerkenInUwBuurt"@nl ;
+   skos:prefLabel "Wegenwerken in uw buurt"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "WegenwerkenInUwBuurt"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie> .
 

--- a/doc/conceptscheme/Notificatiecategorie.ttl
+++ b/doc/conceptscheme/Notificatiecategorie.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Notificatiecategorie>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "De categorie van de notificatie"@nl ;
    skos:prefLabel "NotificatieCategorie"@nl .
 

--- a/doc/conceptscheme/Nutsvoorzieningscodex.ttl
+++ b/doc/conceptscheme/Nutsvoorzieningscodex.ttl
@@ -1,8 +1,8 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes>
+<https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes>
    a skos:ConceptScheme ;
    skos:definition "Aanduiding van de soort nutsvoorziening. Naar GRB-skeletoptie wegbeheer - WNC: nutsvoorzieningscode."@nl ;
-   rdfs:label "Nutsvoorzieningscodes"@nl .
+   skos:prefLabel "Nutsvoorzieningscodes"@nl .
 

--- a/doc/conceptscheme/Nutsvoorzieningscodex.ttl
+++ b/doc/conceptscheme/Nutsvoorzieningscodex.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Aanduiding van de soort nutsvoorziening. Naar GRB-skeletoptie wegbeheer - WNC: nutsvoorzieningscode."@nl ;
    skos:prefLabel "Nutsvoorzieningscodes"@nl .
 

--- a/doc/conceptscheme/Nutsvoorzieningscodex/index.html
+++ b/doc/conceptscheme/Nutsvoorzieningscodex/index.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="nl" lang="nl" dir="ltr" typeof="bibo:Document " about="" property="dcterms:language" content="nl" prefix="dcterms: http://purl.org/dc/terms/ bibo: http://purl.org/ontology/bibo/ schema: http://schema.org/ w3p: http://www.w3.org/2001/02pd/rec54#">
 
 <head>
-  <title>Nauwkeurigsheidsklassen</title>
+  <title>Nutsvoorzieningscodes</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -36,7 +36,7 @@
         <div class="layout layout--wide">
           <div class="grid u-hr">
             <div class="col--9-12 col--1-1--s">
-              <h1 class="h1">Codelijst: Nauwkeurigsheidsklassen</h1>
+              <h1 class="h1">Codelijst: Nutsvoorzieningscodes</h1>
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
@@ -55,10 +55,10 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id="Nauwkeurigheidsklassen"><a href="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen" data-placement="right">Nauwkeurigheidsklassen</a></h3>
+              <h3 class="h3" id="Nutsvoorzieningscodes"><a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes" data-placement="right">Nutsvoorzieningscodes</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
-                    <dt>Beschrijving</dt><dd>De nauwkeurigheid waarmee objecten opgemeten worden hangt af van de meetmethode (terrestrisch of via luchtfotogrammetrie) en van de precisie waarmee objecten op het terrein kunnen aangeduid worden. Het GRB definieert 6 nauwkeurigheidsklassen van A tot en met F. Daarnaast werden op basis van het IMKL datamodel ook nog de waarden 'tot 50cm' en 'tot 100cm' opgenomen.</dd>
+                    <dt>Beschrijving</dt><dd>Aanduiding van de soort nutsvoorziening. Naar GRB-skeletoptie wegbeheer - WNC: nutsvoorzieningscode.</dd>
                     
                   </dl>
                 </div>
@@ -76,101 +76,124 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="Nauwkeurigheidsklassen%3AKlasse%20A" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/A">
+                      <tr id="Nutsvoorzieningscodes%3ABrandstof" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/B">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/A" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/A" data-placement="right">
-                            Klasse A</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/B" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/B" data-placement="right">
+                            Brandstof</a>
                           </code>
                         </td>
-                        <td property="skos:definition">Idealisatienauwkeurigheid van 0,7cm en een relatieve nauwkeurigheid van 4cm.</td>
-                        <td property="skos:note"></td>
-                        <td property="skos:note">A</td>
-                      </tr>
-                    
-                      <tr id="Nauwkeurigheidsklassen%3AKlasse%20B" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/B">
-                        <td>
-                          <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/B" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/B" data-placement="right">
-                            Klasse B</a>
-                          </code>
-                        </td>
-                        <td property="skos:definition">Idealisatienauwkeurigheid van 2cm en een relatieve nauwkeurigheid van 5cm.</td>
+                        <td property="skos:definition">Nutsvoorziening brandstof</td>
                         <td property="skos:note"></td>
                         <td property="skos:note">B</td>
                       </tr>
                     
-                      <tr id="Nauwkeurigheidsklassen%3AKlasse%20C" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/C">
+                      <tr id="Nutsvoorzieningscodes%3ADivers" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/D">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/C" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/C" data-placement="right">
-                            Klasse C</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/D" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/D" data-placement="right">
+                            Divers</a>
                           </code>
                         </td>
-                        <td property="skos:definition">Idealisatienauwkeurigheid van 4cm en een relatieve nauwkeurigheid van 7cm.</td>
-                        <td property="skos:note"></td>
-                        <td property="skos:note">C</td>
-                      </tr>
-                    
-                      <tr id="Nauwkeurigheidsklassen%3AKlasse%20D" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/D">
-                        <td>
-                          <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/D" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/D" data-placement="right">
-                            Klasse D</a>
-                          </code>
-                        </td>
-                        <td property="skos:definition">Idealisatienauwkeurigheid van 15cm en een relatieve nauwkeurigheid van 15cm.</td>
+                        <td property="skos:definition">Nutsvoorziening divers</td>
                         <td property="skos:note"></td>
                         <td property="skos:note">D</td>
                       </tr>
                     
-                      <tr id="Nauwkeurigheidsklassen%3AKlasse%20E" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/E">
+                      <tr id="Nutsvoorzieningscodes%3AElektriciteit" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/E">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/E" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/E" data-placement="right">
-                            Klasse E</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/E" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/E" data-placement="right">
+                            Elektriciteit</a>
                           </code>
                         </td>
-                        <td property="skos:definition">Idealisatienauwkeurigheid van 20cm en een relatieve nauwkeurigheid van 30cm.</td>
+                        <td property="skos:definition">Nutsvoorziening elektriciteit</td>
                         <td property="skos:note"></td>
                         <td property="skos:note">E</td>
                       </tr>
                     
-                      <tr id="Nauwkeurigheidsklassen%3AKlasse%20F" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/F">
+                      <tr id="Nutsvoorzieningscodes%3AGas" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/G">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/F" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/F" data-placement="right">
-                            Klasse F</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/G" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/G" data-placement="right">
+                            Gas</a>
                           </code>
                         </td>
-                        <td property="skos:definition">Geen nauwkeurigheidsinformatie beschikbaar.</td>
+                        <td property="skos:definition">Nutsvoorziening gas</td>
                         <td property="skos:note"></td>
-                        <td property="skos:note">F</td>
+                        <td property="skos:note">G</td>
                       </tr>
                     
-                      <tr id="Nauwkeurigheidsklassen%3ATot%20100%20cm" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/tot100cm">
+                      <tr id="Nutsvoorzieningscodes%3ASturingskast%20pompstation" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/PO">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/tot100cm" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/tot100cm" data-placement="right">
-                            Tot 100 cm</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/PO" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/PO" data-placement="right">
+                            Sturingskast pompstation</a>
                           </code>
                         </td>
-                        <td property="skos:definition">Nauwkeurigheidsgraad tot op 100 cm.
-</td>
+                        <td property="skos:definition">Nutsvoorziening stuuringskast pompstation</td>
                         <td property="skos:note"></td>
-                        <td property="skos:note">tot100cm</td>
+                        <td property="skos:note">PO</td>
                       </tr>
                     
-                      <tr id="Nauwkeurigheidsklassen%3ATot%2050%20cm" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/tot50cm">
+                      <tr id="Nutsvoorzieningscodes%3ATelecom" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/T">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/tot50cm" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nauwkeurigsheidsklassen/tot50cm" data-placement="right">
-                            Tot 50 cm</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/T" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/T" data-placement="right">
+                            Telecom</a>
                           </code>
                         </td>
-                        <td property="skos:definition">Nauwkeurigheidsgraad tot op 50 cm.</td>
+                        <td property="skos:definition">Nutsvoorziening telecom</td>
                         <td property="skos:note"></td>
-                        <td property="skos:note">tot50cm</td>
+                        <td property="skos:note">T</td>
+                      </tr>
+                    
+                      <tr id="Nutsvoorzieningscodes%3ATelkast" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/TE">
+                        <td>
+                          <code property="rdfs:label">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/TE" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/TE" data-placement="right">
+                            Telkast</a>
+                          </code>
+                        </td>
+                        <td property="skos:definition">Nutsvoorziening telkast</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">TE</td>
+                      </tr>
+                    
+                      <tr id="Nutsvoorzieningscodes%3AVerkeersregeling%20installatiekast" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/V">
+                        <td>
+                          <code property="rdfs:label">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/V" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/V" data-placement="right">
+                            Verkeersregeling installatiekast</a>
+                          </code>
+                        </td>
+                        <td property="skos:definition">Nutsvoorziening verkeersregeling installatiekast</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">V</td>
+                      </tr>
+                    
+                      <tr id="Nutsvoorzieningscodes%3AVerlichting" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/L">
+                        <td>
+                          <code property="rdfs:label">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/L" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/L" data-placement="right">
+                            Verlichting</a>
+                          </code>
+                        </td>
+                        <td property="skos:definition">Nutsvoorziening verlichting</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">L</td>
+                      </tr>
+                    
+                      <tr id="Nutsvoorzieningscodes%3AWater" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/W">
+                        <td>
+                          <code property="rdfs:label">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/W" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Nutsvoorzieningscodes/W" data-placement="right">
+                            Water</a>
+                          </code>
+                        </td>
+                        <td property="skos:definition">Nutsvoorziening water</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">W</td>
                       </tr>
                     
                     </tbody>

--- a/doc/conceptscheme/OplaadpuntStekkertypes.ttl
+++ b/doc/conceptscheme/OplaadpuntStekkertypes.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "De stekkertypes voor elektrische voortuigen zoals vastgelegd in de IEC-norm 62196."@nl ;
    skos:prefLabel "Oplaadpunt Stekkertypes"@nl .
 

--- a/doc/conceptscheme/OplaadpuntStekkertypes.ttl
+++ b/doc/conceptscheme/OplaadpuntStekkertypes.ttl
@@ -1,43 +1,48 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes>
+<https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes>
    a skos:ConceptScheme ;
    skos:definition "De stekkertypes voor elektrische voortuigen zoals vastgelegd in de IEC-norm 62196."@nl ;
-   rdfs:label "OplaadpuntStekkertypes"@nl .
+   skos:prefLabel "Oplaadpunt Stekkertypes"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#0>
+<https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/0>
    a skos:Concept ;
-   rdfs:label "0"@nl ;
+   skos:prefLabel "Type 0"@nl ;
    skos:definition "Standaard stekker (Schuko, CEE, ...) - eenfasig 230V, 10A/16A/32A"@nl ;
    skos:notation "0"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> .
 
-<http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#1>
+<https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/1>
    a skos:Concept ;
-   rdfs:label "1"@nl ;
+   skos:prefLabel "Type 1"@nl ;
    skos:definition "Yazaki stekker (SAE J1772) - eenfasig 120V / 240V, 30A"@nl ;
    skos:notation "1"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> .
 
-<http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#2>
+<https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/2>
    a skos:Concept ;
-   rdfs:label "2"@nl ;
+   skos:prefLabel "Type 2"@nl ;
    skos:definition "Mennekes stekker (VDE-AR-E_2623-2-2) - driefasig 400V, 63"@nl ;
    skos:notation "2"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> .
 
-<http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#3>
+<https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/3>
    a skos:Concept ;
-   rdfs:label "3"@nl ;
+   skos:prefLabel "Type 3"@nl ;
    skos:definition "EV Plug Alliance (Scame) - eenfasig, 230V, 32A"@nl ;
    skos:notation "3"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> .
 
-<http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#4>
+<https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/4>
    a skos:Concept ;
-   rdfs:label "4"@nl ;
+   skos:prefLabel "Type 4"@nl ;
    skos:definition "Chademo, 240A - 400V"@nl ;
    skos:notation "4"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes> .
 

--- a/doc/conceptscheme/OplaadpuntStekkertypes/index.html
+++ b/doc/conceptscheme/OplaadpuntStekkertypes/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-06-01</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -55,7 +55,7 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id="Oplaadpunt Stekkertypes"><a href="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes" data-placement="right">Oplaadpunt Stekkertypes</a></h3>
+              <h3 class="h3" id="Oplaadpunt Stekkertypes"><a href="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes" data-placement="right">Oplaadpunt Stekkertypes</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
                     <dt>Beschrijving</dt><dd>De stekkertypes voor elektrische voortuigen zoals vastgelegd in de IEC-norm 62196.</dd>
@@ -76,10 +76,10 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="Oplaadpunt%20Stekkertypes%3AType%200" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#0">
+                      <tr id="Oplaadpunt%20Stekkertypes%3AType%200" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/0">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#0" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#0" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/0" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/0" data-placement="right">
                             Type 0</a>
                           </code>
                         </td>
@@ -88,10 +88,10 @@
                         <td property="skos:note">0</td>
                       </tr>
                     
-                      <tr id="Oplaadpunt%20Stekkertypes%3AType%201" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#1">
+                      <tr id="Oplaadpunt%20Stekkertypes%3AType%201" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/1">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#1" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#1" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/1" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/1" data-placement="right">
                             Type 1</a>
                           </code>
                         </td>
@@ -100,10 +100,10 @@
                         <td property="skos:note">1</td>
                       </tr>
                     
-                      <tr id="Oplaadpunt%20Stekkertypes%3AType%202" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#2">
+                      <tr id="Oplaadpunt%20Stekkertypes%3AType%202" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/2">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#2" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#2" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/2" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/2" data-placement="right">
                             Type 2</a>
                           </code>
                         </td>
@@ -112,10 +112,10 @@
                         <td property="skos:note">2</td>
                       </tr>
                     
-                      <tr id="Oplaadpunt%20Stekkertypes%3AType%203" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#3">
+                      <tr id="Oplaadpunt%20Stekkertypes%3AType%203" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/3">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#3" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#3" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/3" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/3" data-placement="right">
                             Type 3</a>
                           </code>
                         </td>
@@ -124,10 +124,10 @@
                         <td property="skos:note">3</td>
                       </tr>
                     
-                      <tr id="Oplaadpunt%20Stekkertypes%3AType%204" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#4">
+                      <tr id="Oplaadpunt%20Stekkertypes%3AType%204" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/4">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#4" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes#4" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/4" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/OplaadpuntStekkertypes/4" data-placement="right">
                             Type 4</a>
                           </code>
                         </td>

--- a/doc/conceptscheme/Oplaadwijzes.ttl
+++ b/doc/conceptscheme/Oplaadwijzes.ttl
@@ -1,36 +1,40 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes>
+<https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes>
    a skos:ConceptScheme ;
    skos:definition "Oplaadwijzes volgens de IEC norm 62196."@nl ;
-   rdfs:label "Oplaadwijzes"@nl .
+   skos:prefLabel "Oplaadwijzes"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#1>
+<https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/1>
    a skos:Concept ;
-   rdfs:label "1"@nl ;
+   skos:prefLabel "Modus 1 laden"@nl ;
    skos:definition "Onaangepast stopcontact (non-dedicated outlet), standaard stopcontact, tot 10A - 230V"@nl ;
    skos:notation "1"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#2>
+<https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/2>
    a skos:Concept ;
-   rdfs:label "2"@nl ;
+   skos:prefLabel "Modus 2 laden"@nl ;
    skos:definition "Onaangepast stopcontact met een beschermingswijze in de kabel, tot 32A - 230V"@nl ;
    skos:notation "2"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#3>
+<https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/3>
    a skos:Concept ;
-   rdfs:label "3"@nl ;
+   skos:prefLabel "Modus 3 laden"@nl ;
    skos:definition "Speciaal stopcontact (dedicated outlet), tot 64A - 230V/400V"@nl ;
    skos:notation "3"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#4>
+<https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/4>
    a skos:Concept ;
-   rdfs:label "4"@nl ;
+   skos:prefLabel "Oplaadwijzes"@nl ;
    skos:definition "De oplaadwijzes voor elektrische voortuigen zoals vastgelegd in de IEC-norm 62196."@nl ;
    skos:notation "4"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes> .
 

--- a/doc/conceptscheme/Oplaadwijzes.ttl
+++ b/doc/conceptscheme/Oplaadwijzes.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Oplaadwijzes volgens de IEC norm 62196."@nl ;
    skos:prefLabel "Oplaadwijzes"@nl .
 

--- a/doc/conceptscheme/Oplaadwijzes/index.html
+++ b/doc/conceptscheme/Oplaadwijzes/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-06-01</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -55,7 +55,7 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id="Oplaadwijzes"><a href="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes" data-placement="right">Oplaadwijzes</a></h3>
+              <h3 class="h3" id="Oplaadwijzes"><a href="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes" data-placement="right">Oplaadwijzes</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
                     <dt>Beschrijving</dt><dd>Oplaadwijzes volgens de IEC norm 62196.</dd>
@@ -76,10 +76,10 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="Oplaadwijzes%3AModus%201%20laden" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#1">
+                      <tr id="Oplaadwijzes%3AModus%201%20laden" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/1">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#1" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#1" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/1" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/1" data-placement="right">
                             Modus 1 laden</a>
                           </code>
                         </td>
@@ -88,10 +88,10 @@
                         <td property="skos:note">1</td>
                       </tr>
                     
-                      <tr id="Oplaadwijzes%3AModus%202%20laden" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#2">
+                      <tr id="Oplaadwijzes%3AModus%202%20laden" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/2">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#2" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#2" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/2" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/2" data-placement="right">
                             Modus 2 laden</a>
                           </code>
                         </td>
@@ -100,10 +100,10 @@
                         <td property="skos:note">2</td>
                       </tr>
                     
-                      <tr id="Oplaadwijzes%3AModus%203%20laden" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#3">
+                      <tr id="Oplaadwijzes%3AModus%203%20laden" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/3">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#3" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#3" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/3" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/3" data-placement="right">
                             Modus 3 laden</a>
                           </code>
                         </td>
@@ -112,10 +112,10 @@
                         <td property="skos:note">3</td>
                       </tr>
                     
-                      <tr id="Oplaadwijzes%3AOplaadwijzes" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#4">
+                      <tr id="Oplaadwijzes%3AOplaadwijzes" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/4">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#4" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes#4" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/4" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Oplaadwijzes/4" data-placement="right">
                             Oplaadwijzes</a>
                           </code>
                         </td>

--- a/doc/conceptscheme/Sorteerfracties.ttl
+++ b/doc/conceptscheme/Sorteerfracties.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Types materiaal om te sorteren"@nl ;
    skos:prefLabel "Sorteerfracties"@nl .
 

--- a/doc/conceptscheme/Sorteerfracties.ttl
+++ b/doc/conceptscheme/Sorteerfracties.ttl
@@ -1,247 +1,281 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties>
    a skos:ConceptScheme ;
    skos:definition "Types materiaal om te sorteren"@nl ;
-   rdfs:label "Sorteerfracties"@nl .
+   skos:prefLabel "Sorteerfracties"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#AEEA>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/AEEA>
    a skos:Concept ;
-   rdfs:label "AEEA"@nl ;
+   skos:prefLabel "Afgedankte elektrische en elektronische apparaten"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "AEEA"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#AsbesthoudendAfval>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/AsbesthoudendAfval>
    a skos:Concept ;
-   rdfs:label "AsbesthoudendAfval"@nl ;
+   skos:prefLabel "Asbesthoudend afval"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "AsbesthoudendAfval"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Autobanden>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Autobanden>
    a skos:Concept ;
-   rdfs:label "Autobanden"@nl ;
+   skos:prefLabel "Autobanden"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Autobanden"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#BouwEnSloopafval>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/BouwEnSloopafval>
    a skos:Concept ;
-   rdfs:label "BouwEnSloopafval"@nl ;
+   skos:prefLabel "Bouw- en sloopafval"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "BouwEnSloopafval"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Gipsafval>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Gipsafval>
    a skos:Concept ;
-   rdfs:label "Gipsafval"@nl ;
+   skos:prefLabel "Gipsafval"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Gipsafval"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#HolGlas>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/HolGlas>
    a skos:Concept ;
-   rdfs:label "HolGlas"@nl ;
+   skos:prefLabel "Hol glas"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "HolGlas"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#VlakGlas>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/VlakGlas>
    a skos:Concept ;
-   rdfs:label "VlakGlas"@nl ;
+   skos:prefLabel "Vlak glas"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "VlakGlas"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#OnzuiverGlas>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/OnzuiverGlas>
    a skos:Concept ;
-   rdfs:label "OnzuiverGlas"@nl ;
+   skos:prefLabel "Onzuiver glas"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "OnzuiverGlas"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Tuinafval>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Tuinafval>
    a skos:Concept ;
-   rdfs:label "Tuinafval"@nl ;
+   skos:prefLabel "Tuinafval"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Tuinafval"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Grofvuil>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Grofvuil>
    a skos:Concept ;
-   rdfs:label "Grofvuil"@nl ;
+   skos:prefLabel "Grof vuil"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Grofvuil"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Houtafval>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Houtafval>
    a skos:Concept ;
-   rdfs:label "Houtafval"@nl ;
+   skos:prefLabel "Houtafval"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Houtafval"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Snoeihout>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Snoeihout>
    a skos:Concept ;
-   rdfs:label "Snoeihout"@nl ;
+   skos:prefLabel "Snoeihout"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Snoeihout"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Restafval>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Restafval>
    a skos:Concept ;
-   rdfs:label "Restafval"@nl ;
+   skos:prefLabel "Restafval"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Restafval"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Kaarsresten>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Kaarsresten>
    a skos:Concept ;
-   rdfs:label "Kaarsresten"@nl ;
+   skos:prefLabel "Kaarsresten"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Kaarsresten"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#KGA>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/KGA>
    a skos:Concept ;
-   rdfs:label "KGA"@nl ;
+   skos:prefLabel "Klein gevaarlijk afval"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "KGA"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Kurkafval>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Kurkafval>
    a skos:Concept ;
-   rdfs:label "Kurkafval"@nl ;
+   skos:prefLabel "Kurkafval"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Kurkafval"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Metaal>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Metaal>
    a skos:Concept ;
-   rdfs:label "Metaal"@nl ;
+   skos:prefLabel "Metaal"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Metaal"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#PapierEnKarton>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/PapierEnKarton>
    a skos:Concept ;
-   rdfs:label "PapierEnKarton"@nl ;
+   skos:prefLabel "Papier en karton"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "PapierEnKarton"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Piepschuim>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Piepschuim>
    a skos:Concept ;
-   rdfs:label "Piepschuim"@nl ;
+   skos:prefLabel "Piepschuim"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Piepschuim"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#PMD>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/PMD>
    a skos:Concept ;
-   rdfs:label "PMD"@nl ;
+   skos:prefLabel "PMD"@nl ;
    skos:definition "Plastic flessen en flacons
 , metalen verpakkingen en drankkartons."@nl ;
    skos:notation "PMD"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Roofing>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Roofing>
    a skos:Concept ;
-   rdfs:label "Roofing"@nl ;
+   skos:prefLabel "Roofing"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Roofing"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Textiel>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Textiel>
    a skos:Concept ;
-   rdfs:label "Textiel"@nl ;
+   skos:prefLabel "Textiel"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Textiel"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Schoenen>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Schoenen>
    a skos:Concept ;
-   rdfs:label "Schoenen"@nl ;
+   skos:prefLabel "Schoenen"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Schoenen"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#HardePlastics>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/HardePlastics>
    a skos:Concept ;
-   rdfs:label "HardePlastics"@nl ;
+   skos:prefLabel "Harde plastics"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "HardePlastics"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Steenpuin>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Steenpuin>
    a skos:Concept ;
-   rdfs:label "Steenpuin"@nl ;
+   skos:prefLabel "Steenpuin"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Steenpuin"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Plasticfolies>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Plasticfolies>
    a skos:Concept ;
-   rdfs:label "Plasticfolies"@nl ;
+   skos:prefLabel "Plasticfolies"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Plasticfolies"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Accus>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Accus>
    a skos:Concept ;
-   rdfs:label "Accus"@nl ;
+   skos:prefLabel "Accus"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Accus"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Batterijen>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Batterijen>
    a skos:Concept ;
-   rdfs:label "Batterijen"@nl ;
+   skos:prefLabel "Batterijen"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Batterijen"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Boomstronken>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Boomstronken>
    a skos:Concept ;
-   rdfs:label "Boomstronken"@nl ;
+   skos:prefLabel "Boomstronken"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Boomstronken"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#FrituurolieEnVetten>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/FrituurolieEnVetten>
    a skos:Concept ;
-   rdfs:label "FrituurolieEnVetten"@nl ;
+   skos:prefLabel "Frituurolie en vetten"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "FrituurolieEnVetten"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#GFT>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/GFT>
    a skos:Concept ;
-   rdfs:label "GFT"@nl ;
+   skos:prefLabel "Groente-, fruit- en tuinafval"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "GFT"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Lampen>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Lampen>
    a skos:Concept ;
-   rdfs:label "Lampen"@nl ;
+   skos:prefLabel "Lampen"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Lampen"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Smeerolie>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Smeerolie>
    a skos:Concept ;
-   rdfs:label "Smeerolie"@nl ;
+   skos:prefLabel "Smeerolie"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Smeerolie"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Andere>
+<https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Andere>
    a skos:Concept ;
-   rdfs:label "Andere"@nl ;
+   skos:prefLabel "Andere"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Andere"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties> .
 

--- a/doc/conceptscheme/Sorteerfracties/index.html
+++ b/doc/conceptscheme/Sorteerfracties/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-06-08</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -55,7 +55,7 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id="Sorteerfracties"><a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties" data-placement="right">Sorteerfracties</a></h3>
+              <h3 class="h3" id="Sorteerfracties"><a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties" data-placement="right">Sorteerfracties</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
                     <dt>Beschrijving</dt><dd>Types materiaal om te sorteren</dd>
@@ -76,10 +76,10 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="Sorteerfracties%3AAccus" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Accus">
+                      <tr id="Sorteerfracties%3AAccus" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Accus">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Accus" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Accus" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Accus" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Accus" data-placement="right">
                             Accus</a>
                           </code>
                         </td>
@@ -88,10 +88,10 @@
                         <td property="skos:note">Accus</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AAfgedankte%20elektrische%20en%20elektronische%20apparaten" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#AEEA">
+                      <tr id="Sorteerfracties%3AAfgedankte%20elektrische%20en%20elektronische%20apparaten" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/AEEA">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#AEEA" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#AEEA" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/AEEA" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/AEEA" data-placement="right">
                             Afgedankte elektrische en elektronische apparaten</a>
                           </code>
                         </td>
@@ -100,10 +100,10 @@
                         <td property="skos:note">AEEA</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AAndere" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Andere">
+                      <tr id="Sorteerfracties%3AAndere" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Andere">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Andere" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Andere" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Andere" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Andere" data-placement="right">
                             Andere</a>
                           </code>
                         </td>
@@ -112,10 +112,10 @@
                         <td property="skos:note">Andere</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AAsbesthoudend%20afval" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#AsbesthoudendAfval">
+                      <tr id="Sorteerfracties%3AAsbesthoudend%20afval" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/AsbesthoudendAfval">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#AsbesthoudendAfval" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#AsbesthoudendAfval" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/AsbesthoudendAfval" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/AsbesthoudendAfval" data-placement="right">
                             Asbesthoudend afval</a>
                           </code>
                         </td>
@@ -124,10 +124,10 @@
                         <td property="skos:note">AsbesthoudendAfval</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AAutobanden" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Autobanden">
+                      <tr id="Sorteerfracties%3AAutobanden" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Autobanden">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Autobanden" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Autobanden" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Autobanden" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Autobanden" data-placement="right">
                             Autobanden</a>
                           </code>
                         </td>
@@ -136,10 +136,10 @@
                         <td property="skos:note">Autobanden</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ABatterijen" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Batterijen">
+                      <tr id="Sorteerfracties%3ABatterijen" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Batterijen">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Batterijen" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Batterijen" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Batterijen" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Batterijen" data-placement="right">
                             Batterijen</a>
                           </code>
                         </td>
@@ -148,10 +148,10 @@
                         <td property="skos:note">Batterijen</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ABoomstronken" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Boomstronken">
+                      <tr id="Sorteerfracties%3ABoomstronken" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Boomstronken">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Boomstronken" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Boomstronken" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Boomstronken" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Boomstronken" data-placement="right">
                             Boomstronken</a>
                           </code>
                         </td>
@@ -160,10 +160,10 @@
                         <td property="skos:note">Boomstronken</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ABouw-%20en%20sloopafval" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#BouwEnSloopafval">
+                      <tr id="Sorteerfracties%3ABouw-%20en%20sloopafval" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/BouwEnSloopafval">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#BouwEnSloopafval" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#BouwEnSloopafval" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/BouwEnSloopafval" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/BouwEnSloopafval" data-placement="right">
                             Bouw- en sloopafval</a>
                           </code>
                         </td>
@@ -172,10 +172,10 @@
                         <td property="skos:note">BouwEnSloopafval</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AFrituurolie%20en%20vetten" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#FrituurolieEnVetten">
+                      <tr id="Sorteerfracties%3AFrituurolie%20en%20vetten" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/FrituurolieEnVetten">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#FrituurolieEnVetten" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#FrituurolieEnVetten" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/FrituurolieEnVetten" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/FrituurolieEnVetten" data-placement="right">
                             Frituurolie en vetten</a>
                           </code>
                         </td>
@@ -184,10 +184,10 @@
                         <td property="skos:note">FrituurolieEnVetten</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AGipsafval" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Gipsafval">
+                      <tr id="Sorteerfracties%3AGipsafval" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Gipsafval">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Gipsafval" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Gipsafval" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Gipsafval" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Gipsafval" data-placement="right">
                             Gipsafval</a>
                           </code>
                         </td>
@@ -196,10 +196,10 @@
                         <td property="skos:note">Gipsafval</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AGroente-%2C%20fruit-%20en%20tuinafval" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#GFT">
+                      <tr id="Sorteerfracties%3AGroente-%2C%20fruit-%20en%20tuinafval" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/GFT">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#GFT" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#GFT" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/GFT" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/GFT" data-placement="right">
                             Groente-, fruit- en tuinafval</a>
                           </code>
                         </td>
@@ -208,10 +208,10 @@
                         <td property="skos:note">GFT</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AGrof%20vuil" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Grofvuil">
+                      <tr id="Sorteerfracties%3AGrof%20vuil" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Grofvuil">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Grofvuil" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Grofvuil" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Grofvuil" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Grofvuil" data-placement="right">
                             Grof vuil</a>
                           </code>
                         </td>
@@ -220,10 +220,10 @@
                         <td property="skos:note">Grofvuil</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AHarde%20plastics" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#HardePlastics">
+                      <tr id="Sorteerfracties%3AHarde%20plastics" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/HardePlastics">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#HardePlastics" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#HardePlastics" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/HardePlastics" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/HardePlastics" data-placement="right">
                             Harde plastics</a>
                           </code>
                         </td>
@@ -232,10 +232,10 @@
                         <td property="skos:note">HardePlastics</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AHol%20glas" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#HolGlas">
+                      <tr id="Sorteerfracties%3AHol%20glas" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/HolGlas">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#HolGlas" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#HolGlas" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/HolGlas" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/HolGlas" data-placement="right">
                             Hol glas</a>
                           </code>
                         </td>
@@ -244,10 +244,10 @@
                         <td property="skos:note">HolGlas</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AHoutafval" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Houtafval">
+                      <tr id="Sorteerfracties%3AHoutafval" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Houtafval">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Houtafval" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Houtafval" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Houtafval" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Houtafval" data-placement="right">
                             Houtafval</a>
                           </code>
                         </td>
@@ -256,10 +256,10 @@
                         <td property="skos:note">Houtafval</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AKaarsresten" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Kaarsresten">
+                      <tr id="Sorteerfracties%3AKaarsresten" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Kaarsresten">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Kaarsresten" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Kaarsresten" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Kaarsresten" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Kaarsresten" data-placement="right">
                             Kaarsresten</a>
                           </code>
                         </td>
@@ -268,10 +268,10 @@
                         <td property="skos:note">Kaarsresten</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AKlein%20gevaarlijk%20afval" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#KGA">
+                      <tr id="Sorteerfracties%3AKlein%20gevaarlijk%20afval" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/KGA">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#KGA" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#KGA" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/KGA" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/KGA" data-placement="right">
                             Klein gevaarlijk afval</a>
                           </code>
                         </td>
@@ -280,10 +280,10 @@
                         <td property="skos:note">KGA</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AKurkafval" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Kurkafval">
+                      <tr id="Sorteerfracties%3AKurkafval" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Kurkafval">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Kurkafval" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Kurkafval" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Kurkafval" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Kurkafval" data-placement="right">
                             Kurkafval</a>
                           </code>
                         </td>
@@ -292,10 +292,10 @@
                         <td property="skos:note">Kurkafval</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ALampen" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Lampen">
+                      <tr id="Sorteerfracties%3ALampen" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Lampen">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Lampen" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Lampen" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Lampen" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Lampen" data-placement="right">
                             Lampen</a>
                           </code>
                         </td>
@@ -304,10 +304,10 @@
                         <td property="skos:note">Lampen</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AMetaal" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Metaal">
+                      <tr id="Sorteerfracties%3AMetaal" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Metaal">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Metaal" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Metaal" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Metaal" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Metaal" data-placement="right">
                             Metaal</a>
                           </code>
                         </td>
@@ -316,10 +316,10 @@
                         <td property="skos:note">Metaal</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AOnzuiver%20glas" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#OnzuiverGlas">
+                      <tr id="Sorteerfracties%3AOnzuiver%20glas" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/OnzuiverGlas">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#OnzuiverGlas" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#OnzuiverGlas" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/OnzuiverGlas" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/OnzuiverGlas" data-placement="right">
                             Onzuiver glas</a>
                           </code>
                         </td>
@@ -328,10 +328,10 @@
                         <td property="skos:note">OnzuiverGlas</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3APapier%20en%20karton" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#PapierEnKarton">
+                      <tr id="Sorteerfracties%3APapier%20en%20karton" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/PapierEnKarton">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#PapierEnKarton" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#PapierEnKarton" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/PapierEnKarton" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/PapierEnKarton" data-placement="right">
                             Papier en karton</a>
                           </code>
                         </td>
@@ -340,10 +340,10 @@
                         <td property="skos:note">PapierEnKarton</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3APiepschuim" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Piepschuim">
+                      <tr id="Sorteerfracties%3APiepschuim" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Piepschuim">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Piepschuim" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Piepschuim" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Piepschuim" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Piepschuim" data-placement="right">
                             Piepschuim</a>
                           </code>
                         </td>
@@ -352,10 +352,10 @@
                         <td property="skos:note">Piepschuim</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3APlasticfolies" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Plasticfolies">
+                      <tr id="Sorteerfracties%3APlasticfolies" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Plasticfolies">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Plasticfolies" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Plasticfolies" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Plasticfolies" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Plasticfolies" data-placement="right">
                             Plasticfolies</a>
                           </code>
                         </td>
@@ -364,10 +364,10 @@
                         <td property="skos:note">Plasticfolies</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3APMD" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#PMD">
+                      <tr id="Sorteerfracties%3APMD" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/PMD">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#PMD" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#PMD" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/PMD" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/PMD" data-placement="right">
                             PMD</a>
                           </code>
                         </td>
@@ -377,10 +377,10 @@
                         <td property="skos:note">PMD</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ARestafval" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Restafval">
+                      <tr id="Sorteerfracties%3ARestafval" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Restafval">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Restafval" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Restafval" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Restafval" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Restafval" data-placement="right">
                             Restafval</a>
                           </code>
                         </td>
@@ -389,10 +389,10 @@
                         <td property="skos:note">Restafval</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ARoofing" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Roofing">
+                      <tr id="Sorteerfracties%3ARoofing" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Roofing">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Roofing" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Roofing" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Roofing" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Roofing" data-placement="right">
                             Roofing</a>
                           </code>
                         </td>
@@ -401,10 +401,10 @@
                         <td property="skos:note">Roofing</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ASchoenen" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Schoenen">
+                      <tr id="Sorteerfracties%3ASchoenen" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Schoenen">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Schoenen" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Schoenen" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Schoenen" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Schoenen" data-placement="right">
                             Schoenen</a>
                           </code>
                         </td>
@@ -413,10 +413,10 @@
                         <td property="skos:note">Schoenen</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ASmeerolie" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Smeerolie">
+                      <tr id="Sorteerfracties%3ASmeerolie" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Smeerolie">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Smeerolie" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Smeerolie" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Smeerolie" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Smeerolie" data-placement="right">
                             Smeerolie</a>
                           </code>
                         </td>
@@ -425,10 +425,10 @@
                         <td property="skos:note">Smeerolie</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ASnoeihout" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Snoeihout">
+                      <tr id="Sorteerfracties%3ASnoeihout" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Snoeihout">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Snoeihout" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Snoeihout" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Snoeihout" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Snoeihout" data-placement="right">
                             Snoeihout</a>
                           </code>
                         </td>
@@ -437,10 +437,10 @@
                         <td property="skos:note">Snoeihout</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ASteenpuin" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Steenpuin">
+                      <tr id="Sorteerfracties%3ASteenpuin" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Steenpuin">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Steenpuin" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Steenpuin" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Steenpuin" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Steenpuin" data-placement="right">
                             Steenpuin</a>
                           </code>
                         </td>
@@ -449,10 +449,10 @@
                         <td property="skos:note">Steenpuin</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ATextiel" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Textiel">
+                      <tr id="Sorteerfracties%3ATextiel" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Textiel">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Textiel" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Textiel" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Textiel" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Textiel" data-placement="right">
                             Textiel</a>
                           </code>
                         </td>
@@ -461,10 +461,10 @@
                         <td property="skos:note">Textiel</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3ATuinafval" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Tuinafval">
+                      <tr id="Sorteerfracties%3ATuinafval" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Tuinafval">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Tuinafval" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#Tuinafval" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Tuinafval" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/Tuinafval" data-placement="right">
                             Tuinafval</a>
                           </code>
                         </td>
@@ -473,10 +473,10 @@
                         <td property="skos:note">Tuinafval</td>
                       </tr>
                     
-                      <tr id="Sorteerfracties%3AVlak%20glas" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#VlakGlas">
+                      <tr id="Sorteerfracties%3AVlak%20glas" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/VlakGlas">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#VlakGlas" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Sorteerfracties#VlakGlas" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/VlakGlas" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Sorteerfracties/VlakGlas" data-placement="right">
                             Vlak glas</a>
                           </code>
                         </td>

--- a/doc/conceptscheme/SpeelEnSportvoorzieningType.ttl
+++ b/doc/conceptscheme/SpeelEnSportvoorzieningType.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Typering voor speel- en sportvoorziening volgens de EN 1176  norm."@nl ;
    skos:prefLabel "Type speel- en sportvoorziening"@nl .
 

--- a/doc/conceptscheme/SpeelEnSportvoorzieningType.ttl
+++ b/doc/conceptscheme/SpeelEnSportvoorzieningType.ttl
@@ -1,99 +1,112 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType>
    a skos:ConceptScheme ;
    skos:definition "Typering voor speel- en sportvoorziening volgens de EN 1176  norm."@nl ;
-   rdfs:label "SpeelEnSportvoorzieningType"@nl .
+   skos:prefLabel "Type speel- en sportvoorziening"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Draaitoestel>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Draaitoestel>
    a skos:Concept ;
-   rdfs:label "Draaitoestel"@nl ;
+   skos:prefLabel "Draaitoestel"@nl ;
    skos:definition "cf. norm EN 1176-5 - draaitoestellen"@nl ;
    skos:notation "Draaitoestel"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Glijbaan>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Glijbaan>
    a skos:Concept ;
-   rdfs:label "Glijbaan"@nl ;
+   skos:prefLabel "Glijbaan"@nl ;
    skos:definition "cf. norm EN 1176-3 - glijbanen"@nl ;
    skos:notation "Glijbaan"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Kabelbaan>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Kabelbaan>
    a skos:Concept ;
-   rdfs:label "Kabelbaan"@nl ;
+   skos:prefLabel "Kabelbaan"@nl ;
    skos:definition "cf. norm EN 1176-4 - kabelbanen"@nl ;
    skos:notation "Kabelbaan"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Schommel>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Schommel>
    a skos:Concept ;
-   rdfs:label "Schommel"@nl ;
+   skos:prefLabel "Schommel"@nl ;
    skos:definition "cf. norm EN 1176-2 - schommels"@nl ;
    skos:notation "Schommel"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Skatetoestel>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Skatetoestel>
    a skos:Concept ;
-   rdfs:label "Skatetoestel"@nl ;
+   skos:prefLabel "Skatetoestel"@nl ;
    skos:definition "	Specifiek voor rolsport (skaten, skeeleren, BMX'en, ... ) ontworpen toestel (cf. norm EN 14974)"@nl ;
    skos:notation "Skatetoestel"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Algemeen>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Algemeen>
    a skos:Concept ;
-   rdfs:label "Algemeen"@nl ;
+   skos:prefLabel "Algemeen"@nl ;
    skos:definition "Algemeen attribuut dat kan gekozen worden wanneer geen verder detailniveau gewenst is."@nl ;
    skos:notation "Algemeen"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Sportobject>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Sportobject>
    a skos:Concept ;
-   rdfs:label "Sportobject"@nl ;
+   skos:prefLabel "Sportobject"@nl ;
    skos:definition "Een toestel dat gebruikt kan worden om te sporten."@nl ;
    skos:notation "Sportobject"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#VolledigOmsloten>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/VolledigOmsloten>
    a skos:Concept ;
-   rdfs:label "VolledigOmsloten"@nl ;
+   skos:prefLabel "Volledig omsloten"@nl ;
    skos:definition "cf. norm EN 1176-10 - volledig omsloten speeltoestellen"@nl ;
    skos:notation "VolledigOmsloten"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Wip>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Wip>
    a skos:Concept ;
-   rdfs:label "Wip"@nl ;
+   skos:prefLabel "Wip"@nl ;
    skos:definition "cf. norm EN 1176-6 - wiptoestellen"@nl ;
    skos:notation "Wip"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Zandbak>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Zandbak>
    a skos:Concept ;
-   rdfs:label "Zandbak"@nl ;
+   skos:prefLabel "Zandbak"@nl ;
    skos:definition "Speeltoestel dat ontworpen is om zand te bevatten, en waar het zand als spelmateriaal wordt gebruikt."@nl ;
    skos:notation "Zandbak"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Netstructuur>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Netstructuur>
    a skos:Concept ;
-   rdfs:label "Netstructuur"@nl ;
+   skos:prefLabel "Netstructuur"@nl ;
    skos:definition "cf. norm EN 1176-11 - ruimtelijke netstructuren"@nl ;
    skos:notation "Netstructuur"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Klimwand>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Klimwand>
    a skos:Concept ;
-   rdfs:label "Klimwand"@nl ;
+   skos:prefLabel "Klimwand"@nl ;
    skos:definition "Sportuitrusting bestaande uit een klimstructuur speciaal gebouwd voor dit doeleinde, met verschillende bouwkenmerken, en ontworpen voor diverse toepassingen binnen de klimsport en niet voorbehouden aan een bepaalde leeftijd. Cf. EN norm 12572-1."@nl ;
    skos:notation "Klimwand"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 
-<http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Klimrek>
+<https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Klimrek>
    a skos:Concept ;
-   rdfs:label "Klimrek"@nl ;
+   skos:prefLabel "Kimrek"@nl ;
    skos:definition "Een klimrek is een sport- of speeltoestel waarin geklommen kan worden."@nl ;
    skos:notation "Klimrek"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType> .
 

--- a/doc/conceptscheme/SpeelEnSportvoorzieningType/index.html
+++ b/doc/conceptscheme/SpeelEnSportvoorzieningType/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-06-05</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -55,7 +55,7 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id="Type speel- en sportvoorziening"><a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType" data-placement="right">Type speel- en sportvoorziening</a></h3>
+              <h3 class="h3" id="Type speel- en sportvoorziening"><a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType" data-placement="right">Type speel- en sportvoorziening</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
                     <dt>Beschrijving</dt><dd>Typering voor speel- en sportvoorziening volgens de EN 1176  norm.</dd>
@@ -76,10 +76,10 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3AAlgemeen" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Algemeen">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3AAlgemeen" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Algemeen">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Algemeen" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Algemeen" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Algemeen" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Algemeen" data-placement="right">
                             Algemeen</a>
                           </code>
                         </td>
@@ -88,10 +88,10 @@
                         <td property="skos:note">Algemeen</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3ADraaitoestel" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Draaitoestel">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3ADraaitoestel" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Draaitoestel">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Draaitoestel" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Draaitoestel" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Draaitoestel" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Draaitoestel" data-placement="right">
                             Draaitoestel</a>
                           </code>
                         </td>
@@ -100,10 +100,10 @@
                         <td property="skos:note">Draaitoestel</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3AGlijbaan" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Glijbaan">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3AGlijbaan" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Glijbaan">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Glijbaan" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Glijbaan" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Glijbaan" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Glijbaan" data-placement="right">
                             Glijbaan</a>
                           </code>
                         </td>
@@ -112,10 +112,10 @@
                         <td property="skos:note">Glijbaan</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3AKabelbaan" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Kabelbaan">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3AKabelbaan" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Kabelbaan">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Kabelbaan" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Kabelbaan" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Kabelbaan" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Kabelbaan" data-placement="right">
                             Kabelbaan</a>
                           </code>
                         </td>
@@ -124,10 +124,10 @@
                         <td property="skos:note">Kabelbaan</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3AKimrek" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Klimrek">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3AKimrek" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Klimrek">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Klimrek" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Klimrek" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Klimrek" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Klimrek" data-placement="right">
                             Kimrek</a>
                           </code>
                         </td>
@@ -136,10 +136,10 @@
                         <td property="skos:note">Klimrek</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3AKlimwand" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Klimwand">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3AKlimwand" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Klimwand">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Klimwand" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Klimwand" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Klimwand" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Klimwand" data-placement="right">
                             Klimwand</a>
                           </code>
                         </td>
@@ -148,10 +148,10 @@
                         <td property="skos:note">Klimwand</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3ANetstructuur" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Netstructuur">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3ANetstructuur" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Netstructuur">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Netstructuur" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Netstructuur" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Netstructuur" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Netstructuur" data-placement="right">
                             Netstructuur</a>
                           </code>
                         </td>
@@ -160,10 +160,10 @@
                         <td property="skos:note">Netstructuur</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3ASchommel" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Schommel">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3ASchommel" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Schommel">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Schommel" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Schommel" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Schommel" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Schommel" data-placement="right">
                             Schommel</a>
                           </code>
                         </td>
@@ -172,10 +172,10 @@
                         <td property="skos:note">Schommel</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3ASkatetoestel" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Skatetoestel">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3ASkatetoestel" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Skatetoestel">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Skatetoestel" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Skatetoestel" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Skatetoestel" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Skatetoestel" data-placement="right">
                             Skatetoestel</a>
                           </code>
                         </td>
@@ -184,10 +184,10 @@
                         <td property="skos:note">Skatetoestel</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3ASportobject" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Sportobject">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3ASportobject" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Sportobject">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Sportobject" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Sportobject" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Sportobject" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Sportobject" data-placement="right">
                             Sportobject</a>
                           </code>
                         </td>
@@ -196,10 +196,10 @@
                         <td property="skos:note">Sportobject</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3AVolledig%20omsloten" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#VolledigOmsloten">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3AVolledig%20omsloten" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/VolledigOmsloten">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#VolledigOmsloten" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#VolledigOmsloten" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/VolledigOmsloten" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/VolledigOmsloten" data-placement="right">
                             Volledig omsloten</a>
                           </code>
                         </td>
@@ -208,10 +208,10 @@
                         <td property="skos:note">VolledigOmsloten</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3AWip" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Wip">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3AWip" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Wip">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Wip" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Wip" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Wip" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Wip" data-placement="right">
                             Wip</a>
                           </code>
                         </td>
@@ -220,10 +220,10 @@
                         <td property="skos:note">Wip</td>
                       </tr>
                     
-                      <tr id="Type%20speel-%20en%20sportvoorziening%3AZandbak" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Zandbak">
+                      <tr id="Type%20speel-%20en%20sportvoorziening%3AZandbak" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Zandbak">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Zandbak" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType#Zandbak" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Zandbak" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/SpeelEnSportvoorzieningType/Zandbak" data-placement="right">
                             Zandbak</a>
                           </code>
                         </td>

--- a/doc/conceptscheme/StatusVlaamseCode.ttl
+++ b/doc/conceptscheme/StatusVlaamseCode.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Informatie over de status van het dossier. De statusinformatie bevat een op Vlaams niveau gestandaardiseerde status code."@nl ;
    skos:prefLabel "Status Vlaamse Code"@nl .
 

--- a/doc/conceptscheme/StatusVlaamseCode.ttl
+++ b/doc/conceptscheme/StatusVlaamseCode.ttl
@@ -1,29 +1,224 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<https://data.vlaanderen.be/id/conceptscheme/Contactkanaal>
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode>
    a skos:ConceptScheme ;
-   skos:definition "Het technisch medium waarlangs het notificatie wordt verzonden."@nl ;
-   rdfs:label "Contactkanaal"@nl .
+   skos:definition "Informatie over de status van het dossier. De statusinformatie bevat een op Vlaams niveau gestandaardiseerde status code."@nl ;
+   skos:prefLabel "Status Vlaamse Code"@nl .
 
-<https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Passief>
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/InVerwerking>
    a skos:Concept ;
-   rdfs:label "Passief"@nl ;
-   skos:definition "Passieve notificaties worden enkel getoond binnen een bepaalde toestemming na authenticatie van de gebruiker."@nl ;
-   skos:notation "Passief"@nl ;
-   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Contactkanaal> .
+   skos:prefLabel "In verwerking"@nl ;
+   skos:definition "De behandelende overheid is bezig met de verwerking van het dossier."@nl ;
+   skos:notation "InVerwerking"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
 
-<https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Sms>
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/BeslissingGepubliceerd>
    a skos:Concept ;
-   rdfs:label "Sms"@nl ;
-   skos:definition "Contact via tekstberichten die via sms naar een telefoonnummer verzonden worden."@nl ;
-   skos:notation "Sms"@nl ;
-   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Contactkanaal> .
+   skos:prefLabel "(Beslissing) Gepubliceerd"@nl ;
+   skos:definition "Een of meerdere beslissingen van de behandelende overheid worden gepubliceerd volgens de wettelijke vereisten hierover."@nl ;
+   skos:notation "BeslissingGepubliceerd"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
 
-<https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Email>
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Beroep>
    a skos:Concept ;
-   rdfs:label "Email"@nl ;
-   skos:definition "Contact via e-mail."@nl ;
-   skos:notation "Email"@nl ;
-   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Contactkanaal> .
+   skos:prefLabel "Beroep"@nl ;
+   skos:definition "De dossieraanvrager gaat niet akkoord met een bepaald onderdeel van de dossierverwerking door de behandelende overheid en dient hier een formeel protest tegen in."@nl ;
+   skos:notation "Beroep"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Beslist>
+   a skos:Concept ;
+   skos:prefLabel "Beslist"@nl ;
+   skos:definition "De behandelende overheid beslist na het verwerken en het controleren van het dossier over het dossier in kwestie."@nl ;
+   skos:notation "Beslist"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Betaald>
+   a skos:Concept ;
+   skos:prefLabel "Betaald"@nl ;
+   skos:definition "De behandelende overheid heeft, na verwerking en beslissing van het dossier, alle voorziene vergoeding(en) uitbetaald."@nl ;
+   skos:notation "Betaald"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Bezwaar>
+   a skos:Concept ;
+   skos:prefLabel "Bezwaar"@nl ;
+   skos:definition "De behandelende overheid herroept formeel een eerdere beslissing of actie in de verwerking van een dossier."@nl ;
+   skos:notation "Bezwaar"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/DeelsGoedgekeurd>
+   a skos:Concept ;
+   skos:prefLabel "Deels goedgekeurd"@nl ;
+   skos:definition "De behandelende overheid gaf na het verwerken en het controleren van het dossier haar goedkeuring over een deel van de aanvraag."@nl ;
+   skos:notation "DeelsGoedgekeurd"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/DeelsUitbetaald>
+   a skos:Concept ;
+   skos:prefLabel "Deels uitbetaald"@nl ;
+   skos:definition "De behandelende overheid heeft, na verwerking en beslissing van het dossier, een deel van de voorziene vergoeding(en) uitbetaald."@nl ;
+   skos:notation "DeelsUitbetaald"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/DossierOnvolledig>
+   a skos:Concept ;
+   skos:prefLabel "Dossier onvolledig"@nl ;
+   skos:definition "De behandelende overheid heeft vastgesteld dat niet alle nodige gegevens om het dossier te kunnen verwerken aan het dossier werden toegevoegd. De aanvrager van het dossier krijgt de tijd om alle nodige gegevens te verzamelen en aan het dossier toe te voegen."@nl ;
+   skos:notation "DossierOnvolledig"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/DossierVolledig>
+   a skos:Concept ;
+   skos:prefLabel "Dossier volledig"@nl ;
+   skos:definition "De behandelende overheid heeft vastgesteld dat alle nodige gegevens om het dossier te kunnen verwerken aan het dossier werden toegevoegd."@nl ;
+   skos:notation "DossierVolledig"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/ErkendOfVergund>
+   a skos:Concept ;
+   skos:prefLabel "Erkend/Vergund"@nl ;
+   skos:definition "De behandelende overheid heeft een vergunning of erkenning uitgereikt aan het voorwerp/onderwerp van het dossier."@nl ;
+   skos:notation "ErkendOfVergund"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/ErkenningOfVergunningIngetrokken>
+   a skos:Concept ;
+   skos:prefLabel "Erkenning/vergunning ingetrokken"@nl ;
+   skos:definition "De behandelende overheid heeft een vergunning of erkenning die zij eerder had uitgereikt ingetrokken."@nl ;
+   skos:notation "ErkenningOfVergunningIngetrokken"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Geinitieerd>
+   a skos:Concept ;
+   skos:prefLabel "Geïnitieerd"@nl ;
+   skos:definition "De aanvrager van een dossier heeft de intentie of interesse duidelijk gemaakt aan de behandelende overheid om een dossier te willen indienen maar heeft dit nog niet formeel gedaan."@nl ;
+   skos:notation "Geinitieerd"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Geweigerd>
+   a skos:Concept ;
+   skos:prefLabel "Geweigerd"@nl ;
+   skos:definition "De behandelende overheid weigert om bepaalde redenen het dossier in behandeling te nemen of verder te behandelen."@nl ;
+   skos:notation "Geweigerd"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Goedgekeurd>
+   a skos:Concept ;
+   skos:prefLabel "Goedgekeurd"@nl ;
+   skos:definition "De behandelende overheid gaf na het verwerken en het controleren van het dossier haar goedkeuring."@nl ;
+   skos:notation "Goedgekeurd"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/InWacht>
+   a skos:Concept ;
+   skos:prefLabel "In wacht"@nl ;
+   skos:definition "De behandelende overheid heeft de verwerking van het dossier tijdelijk stopgezet omwille van bepaalde (externe) factoren zoals bijvoorbeeld een actie van een derde of het verstrijken van een termijn."@nl ;
+   skos:notation "InWacht"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Ingediend>
+   a skos:Concept ;
+   skos:prefLabel "Ingediend"@nl ;
+   skos:definition "De aanvrager van een dossier heeft een dossieraanvraag ingediend."@nl ;
+   skos:notation "Ingediend"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/KlaarVoorBeslissing>
+   a skos:Concept ;
+   skos:prefLabel "Klaar voor beslissing"@nl ;
+   skos:definition "De behandelende overheid heeft de nodige verwerking en controles op het dossier uitgevoerd zodat het dossier klaar is om over beslist te worden."@nl ;
+   skos:notation "KlaarVoorBeslissing"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/KlaarVoorBetaling>
+   a skos:Concept ;
+   skos:prefLabel "Klaar voor betaling"@nl ;
+   skos:definition "De behandelende overheid is, na verwerking en beslissing over het dossier, klaar om de voorziene vergoeding(en) uit te betalen en heeft de uit te betalen bedragen vastgelegd."@nl ;
+   skos:notation "KlaarVoorBetaling"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Onontvankelijk>
+   a skos:Concept ;
+   skos:prefLabel "Onontvankelijk"@nl ;
+   skos:definition "De behandelende overheid heeft vastgesteld dat niet alle nodige voorwaarden werden vervuld om het dossier rechtsgeldig in behandeling te nemen. Daarbij krijgt de aanvrager van het dossier niet meer de mogelijkheid om de ontbrekende voorwaarden alsnog te vervullen."@nl ;
+   skos:notation "Onontvankelijk"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Ontvangen>
+   a skos:Concept ;
+   skos:prefLabel "Ontvangen"@nl ;
+   skos:definition "De behandelende overheid heeft de dossieraanvraag formeel ontvangen."@nl ;
+   skos:notation "Ontvangen"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Ontvankelijk>
+   a skos:Concept ;
+   skos:prefLabel "Ontvankelijk"@nl ;
+   skos:definition "De behandelende overheid heeft vastgesteld dat alle nodige voorwaarden werden vervuld om het dossier rechtsgeldig in behandeling te kunnen nemen."@nl ;
+   skos:notation "Ontvankelijk"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Stopgezet>
+   a skos:Concept ;
+   skos:prefLabel "Stopgezet"@nl ;
+   skos:definition "De behandelende overheid heeft de verwerking of de beslissing van/over het dossier stopgezet vooraleer het volgens het behandelproces kon worden afgerond."@nl ;
+   skos:notation "Stopgezet"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Stopzetting>
+   a skos:Concept ;
+   skos:prefLabel "Stopzetting"@nl ;
+   skos:definition "De verwerking of de beslissing van het dossier is in een proces van stopzetting beland nog voor het dossier volgens het behandelproces kon worden afgerond."@nl ;
+   skos:notation "Stopzetting"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Terugbetaald>
+   a skos:Concept ;
+   skos:prefLabel "Terugbetaald"@nl ;
+   skos:definition "De bevoegde overheid heeft uitgaven, gemaakt door de aanvrager van een dossier of diens betrokkene, terugbetaald na verwerking van de dossieraanvraag en gunstige beslissing."@nl ;
+   skos:notation "Terugbetaald"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/TerugvorderingBetaling>
+   a skos:Concept ;
+   skos:prefLabel "Terugvordering betaling"@nl ;
+   skos:definition "De behandelende overheid vordert een bedrag terug van de begunstigde."@nl ;
+   skos:notation "TerugvorderingBetaling"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
+
+<https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode/Uitgevoerd>
+   a skos:Concept ;
+   skos:prefLabel "Uitgevoerd"@nl ;
+   skos:definition "De behandelende overheid heeft de nodige acties in de verwerking van het dossier uitgevoerd."@nl ;
+   skos:notation "Uitgevoerd"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseCode> .
 

--- a/doc/conceptscheme/StatusVlaamseFase.ttl
+++ b/doc/conceptscheme/StatusVlaamseFase.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Informatie over de status van het dossier. De statusinformatie bevat een op Vlaams niveau gestandaardiseerde fase."@nl ;
    skos:prefLabel "Status Vlaamse Fase"@nl .
 

--- a/doc/conceptscheme/StatusVlaamseFase.ttl
+++ b/doc/conceptscheme/StatusVlaamseFase.ttl
@@ -4,40 +4,45 @@
 <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase>
    a skos:ConceptScheme ;
    skos:definition "Informatie over de status van het dossier. De statusinformatie bevat een op Vlaams niveau gestandaardiseerde fase."@nl ;
-   rdfs:label "StatusVlaamseFase"@nl .
+   skos:prefLabel "Status Vlaamse Fase"@nl .
 
 <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Samenstelling>
    a skos:Concept ;
-   rdfs:label "Samenstelling"@nl ;
+   skos:prefLabel "Samenstelling"@nl ;
    skos:definition "In deze fase worden bepaalde gegevens verzameld om het dossier (rechts)geldig in behandeling te kunnen nemen."@nl ;
    skos:notation "Samenstelling"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase> .
 
 <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Behandeling>
    a skos:Concept ;
-   rdfs:label "Behandeling"@nl ;
+   skos:prefLabel "Behandeling"@nl ;
    skos:definition "In deze fase verwerkt en beoordeelt de behandelende overheid de verzamelde gegevens (in voorbereiding van een beslissing)."@nl ;
    skos:notation "Behandeling"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase> .
 
 <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Beslissing>
    a skos:Concept ;
-   rdfs:label "Beslissing"@nl ;
+   skos:prefLabel "Beslissing"@nl ;
    skos:definition "In deze fase wordt een formele beslissing genomen en bekendgemaakt."@nl ;
    skos:notation "Beslissing"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase> .
 
 <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Uitvoering>
    a skos:Concept ;
-   rdfs:label "Uitvoering"@nl ;
+   skos:prefLabel "Uitvoering"@nl ;
    skos:definition "In deze fase worden de nodige daden, verbonden aan de beslissing in het dossier, uitgevoerd volgens de geldende voorschriften."@nl ;
    skos:notation "Uitvoering"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase> .
 
 <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Afgerond>
    a skos:Concept ;
-   rdfs:label "Afgerond"@nl ;
+   skos:prefLabel "Afgerond"@nl ;
    skos:definition "Het eindpunt in de levensloop van een dossier. Wanneer een dossier het eindpunt 'afgerond' heeft bereikt zijn alle nodige acties in dit dossier uitgevoerd."@nl ;
    skos:notation "Afgerond"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase> .
 

--- a/doc/conceptscheme/StatusVlaamseFase/index.html
+++ b/doc/conceptscheme/StatusVlaamseFase/index.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="nl" lang="nl" dir="ltr" typeof="bibo:Document " about="" property="dcterms:language" content="nl" prefix="dcterms: http://purl.org/dc/terms/ bibo: http://purl.org/ontology/bibo/ schema: http://schema.org/ w3p: http://www.w3.org/2001/02pd/rec54#">
 
 <head>
-  <title>Contactkanaal</title>
+  <title>StatusVlaamseFase</title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -36,7 +36,7 @@
         <div class="layout layout--wide">
           <div class="grid u-hr">
             <div class="col--9-12 col--1-1--s">
-              <h1 class="h1">Codelijst: Contactkanaal</h1>
+              <h1 class="h1">Codelijst: StatusVlaamseFase</h1>
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
@@ -55,10 +55,10 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id="Notificatiekanaal"><a href="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal" data-placement="right">Notificatiekanaal</a></h3>
+              <h3 class="h3" id="Status Vlaamse Fase"><a href="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase" data-placement="right">Status Vlaamse Fase</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
-                    <dt>Beschrijving</dt><dd>Het technisch medium waarlangs het notificatie wordt verzonden.</dd>
+                    <dt>Beschrijving</dt><dd>Informatie over de status van het dossier. De statusinformatie bevat een op Vlaams niveau gestandaardiseerde fase.</dd>
                     
                   </dl>
                 </div>
@@ -76,40 +76,64 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="Notificatiekanaal%3AE-mail" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Email">
+                      <tr id="Status%20Vlaamse%20Fase%3AAfgerond" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Afgerond">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Email" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Email" data-placement="right">
-                            E-mail</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Afgerond" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Afgerond" data-placement="right">
+                            Afgerond</a>
                           </code>
                         </td>
-                        <td property="skos:definition">Contact via e-mail.</td>
+                        <td property="skos:definition">Het eindpunt in de levensloop van een dossier. Wanneer een dossier het eindpunt 'afgerond' heeft bereikt zijn alle nodige acties in dit dossier uitgevoerd.</td>
                         <td property="skos:note"></td>
-                        <td property="skos:note">Email</td>
+                        <td property="skos:note">Afgerond</td>
                       </tr>
                     
-                      <tr id="Notificatiekanaal%3APassief" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Passief">
+                      <tr id="Status%20Vlaamse%20Fase%3ABehandeling" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Behandeling">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Passief" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Passief" data-placement="right">
-                            Passief</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Behandeling" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Behandeling" data-placement="right">
+                            Behandeling</a>
                           </code>
                         </td>
-                        <td property="skos:definition">Passieve notificaties worden enkel getoond binnen een bepaalde toestemming na authenticatie van de gebruiker.</td>
+                        <td property="skos:definition">In deze fase verwerkt en beoordeelt de behandelende overheid de verzamelde gegevens (in voorbereiding van een beslissing).</td>
                         <td property="skos:note"></td>
-                        <td property="skos:note">Passief</td>
+                        <td property="skos:note">Behandeling</td>
                       </tr>
                     
-                      <tr id="Notificatiekanaal%3ASMS" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Sms">
+                      <tr id="Status%20Vlaamse%20Fase%3ABeslissing" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Beslissing">
                         <td>
                           <code property="rdfs:label">
-                            <a href="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Sms" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Contactkanaal/Sms" data-placement="right">
-                            SMS</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Beslissing" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Beslissing" data-placement="right">
+                            Beslissing</a>
                           </code>
                         </td>
-                        <td property="skos:definition">Contact via tekstberichten die via sms naar een telefoonnummer verzonden worden.</td>
+                        <td property="skos:definition">In deze fase wordt een formele beslissing genomen en bekendgemaakt.</td>
                         <td property="skos:note"></td>
-                        <td property="skos:note">Sms</td>
+                        <td property="skos:note">Beslissing</td>
+                      </tr>
+                    
+                      <tr id="Status%20Vlaamse%20Fase%3ASamenstelling" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Samenstelling">
+                        <td>
+                          <code property="rdfs:label">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Samenstelling" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Samenstelling" data-placement="right">
+                            Samenstelling</a>
+                          </code>
+                        </td>
+                        <td property="skos:definition">In deze fase worden bepaalde gegevens verzameld om het dossier (rechts)geldig in behandeling te kunnen nemen.</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">Samenstelling</td>
+                      </tr>
+                    
+                      <tr id="Status%20Vlaamse%20Fase%3AUitvoering" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Uitvoering">
+                        <td>
+                          <code property="rdfs:label">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Uitvoering" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/StatusVlaamseFase/Uitvoering" data-placement="right">
+                            Uitvoering</a>
+                          </code>
+                        </td>
+                        <td property="skos:definition">In deze fase worden de nodige daden, verbonden aan de beslissing in het dossier, uitgevoerd volgens de geldende voorschriften.</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">Uitvoering</td>
                       </tr>
                     
                     </tbody>

--- a/doc/conceptscheme/Straatkolktypes.ttl
+++ b/doc/conceptscheme/Straatkolktypes.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Het type straatkolk naar de GRB classificatie."@nl ;
    skos:prefLabel "Types straatkolken"@nl .
 

--- a/doc/conceptscheme/Straatkolktypes.ttl
+++ b/doc/conceptscheme/Straatkolktypes.ttl
@@ -1,32 +1,35 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes>
+<https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes>
    a skos:ConceptScheme ;
    skos:definition "Het type straatkolk naar de GRB classificatie."@nl ;
-   rdfs:label "Straatkolktypes"@nl .
+   skos:prefLabel "Types straatkolken"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#horizontaal>
+<https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/horizontaal>
    a skos:Concept ;
-   rdfs:label "horizontaal"@nl ;
+   skos:prefLabel "Horizontaal"@nl ;
    skos:definition "Een gietijzeren rooster met horizontale afvoeropening dat op regelmatige afstand geplaatst wordt langs of in een weg, fietspad of voetpad."@nl ;
    skos:note "Naar GRB-skeletaanvulling detail - WPI9: waterslikker : horizontaal"@nl ;
    skos:notation "horizontaal"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#verticaal>
+<https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/verticaal>
    a skos:Concept ;
-   rdfs:label "verticaal"@nl ;
+   skos:prefLabel "Verticaal"@nl ;
    skos:definition "Verticale afvoeropening die op regelmatige afstand geplaatst wordt langs of in een boordsteen van de weg, fietspad of voetpad."@nl ;
    skos:note "Naar GRB-skeletaanvulling detail - WPI9: waterslikker : verticaal"@nl ;
    skos:notation "verticaal"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#geisoleerd>
+<https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/geisoleerd>
    a skos:Concept ;
-   rdfs:label "geisoleerd"@nl ;
+   skos:prefLabel "Geïsoleerd"@nl ;
    skos:definition "Een straatkolk die niet in een rij geplaatst werd maar bijvoorbeeld ergens solitair op een plein."@nl ;
    skos:note "Naar GRB-skeletaanvulling detail - WPI9: waterslikker : geïsoleerd"@nl ;
    skos:notation "geisoleerd"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes> .
 

--- a/doc/conceptscheme/Straatkolktypes/index.html
+++ b/doc/conceptscheme/Straatkolktypes/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-06-01</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -55,7 +55,7 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id="Types straatkolken"><a href="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes" data-placement="right">Types straatkolken</a></h3>
+              <h3 class="h3" id="Types straatkolken"><a href="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes" data-placement="right">Types straatkolken</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
                     <dt>Beschrijving</dt><dd>Het type straatkolk naar de GRB classificatie.</dd>
@@ -76,10 +76,10 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="Types%20straatkolken%3AGe%C3%83%C2%AFsoleerd" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#geisoleerd">
+                      <tr id="Types%20straatkolken%3AGe%C3%83%C2%AFsoleerd" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/geisoleerd">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#geisoleerd" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#geisoleerd" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/geisoleerd" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/geisoleerd" data-placement="right">
                             Ge&#195;&#175;soleerd</a>
                           </code>
                         </td>
@@ -88,10 +88,10 @@
                         <td property="skos:note">geisoleerd</td>
                       </tr>
                     
-                      <tr id="Types%20straatkolken%3AHorizontaal" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#horizontaal">
+                      <tr id="Types%20straatkolken%3AHorizontaal" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/horizontaal">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#horizontaal" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#horizontaal" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/horizontaal" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/horizontaal" data-placement="right">
                             Horizontaal</a>
                           </code>
                         </td>
@@ -100,10 +100,10 @@
                         <td property="skos:note">horizontaal</td>
                       </tr>
                     
-                      <tr id="Types%20straatkolken%3AVerticaal" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#verticaal">
+                      <tr id="Types%20straatkolken%3AVerticaal" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/verticaal">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#verticaal" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptscheme/Straatkolktypes#verticaal" data-placement="right">
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/verticaal" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/Straatkolktypes/verticaal" data-placement="right">
                             Verticaal</a>
                           </code>
                         </td>

--- a/doc/conceptscheme/TaludWaarde.ttl
+++ b/doc/conceptscheme/TaludWaarde.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/TaludWaarde>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Codelijst voor de de hellingsgraad van een talud."@nl ;
    skos:prefLabel "Talud waarde"@nl .
 

--- a/doc/conceptscheme/TaludWaarde.ttl
+++ b/doc/conceptscheme/TaludWaarde.ttl
@@ -1,29 +1,32 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/TaludWaarde>
+<https://data.vlaanderen.be/id/conceptscheme/TaludWaarde>
    a skos:ConceptScheme ;
    skos:definition "Codelijst voor de de hellingsgraad van een talud."@nl ;
-   rdfs:label "TaludWaarde"@nl .
+   skos:prefLabel "Talud waarde"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/TaludWaarde#TOT_1_3>
+<https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/TOT_1_3>
    a skos:Concept ;
-   rdfs:label "TOT_1_3"@nl ;
+   skos:prefLabel ""@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "TOT_1_3"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/TaludWaarde> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/TaludWaarde> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/TaludWaarde> .
 
-<http://data.vlaanderen.be/id/conceptscheme/TaludWaarde#VAN_1_3_TOT_1_2>
+<https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/VAN_1_3_TOT_1_2>
    a skos:Concept ;
-   rdfs:label "VAN_1_3_TOT_1_2"@nl ;
+   skos:prefLabel ""@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "VAN_1_3_TOT_1_2"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/TaludWaarde> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/TaludWaarde> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/TaludWaarde> .
 
-<http://data.vlaanderen.be/id/conceptscheme/TaludWaarde#VAN_1_2_EN_STEILER>
+<https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/VAN_1_2_EN_STEILER>
    a skos:Concept ;
-   rdfs:label "VAN_1_2_EN_STEILER"@nl ;
+   skos:prefLabel ""@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "VAN_1_2_EN_STEILER"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/TaludWaarde> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/TaludWaarde> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/TaludWaarde> .
 

--- a/doc/conceptscheme/TaludWaarde/index.html
+++ b/doc/conceptscheme/TaludWaarde/index.html
@@ -40,7 +40,7 @@
               <div class="head" role="contentinfo" id="respecHeader">
                 <dl>
                   <dt>Laatste aanpassing</dt>
-                  <dd>2018-02-07</dd>
+                  <dd>2018-07-23</dd>
                 </dl>
               </div>
             </div>
@@ -55,10 +55,10 @@
             
             
             <div class="region region--no-space-top">
-              <h3 class="h3" id="TaludWaarde"><a href="http://data.vlaanderen.be/id/conceptschema/TaludWaarde" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptschema/TaludWaarde" data-placement="right">TaludWaarde</a></h3>
+              <h3 class="h3" id="Talud waarde"><a href="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde" data-placement="right">Talud waarde</a></h3>
                 <div class="region region--no-space-top">
                   <dl>
-                    <dt>Beschrijving</dt><dd>TODO</dd>
+                    <dt>Beschrijving</dt><dd>Codelijst voor de de hellingsgraad van een talud.</dd>
                     
                   </dl>
                 </div>
@@ -76,40 +76,40 @@
         
                     <tbody class="supertype">
                     
-                      <tr id="TaludWaarde%3ATot%201%203" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptschema/TaludWaarde#TOT_1_3">
+                      <tr id="Talud%20waarde%3A" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/TOT_1_3">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptschema/TaludWaarde#TOT_1_3" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptschema/TaludWaarde#TOT_1_3" data-placement="right">
-                            Tot 1 3</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/TOT_1_3" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/TOT_1_3" data-placement="right">
+                            </a>
                           </code>
                         </td>
-                        <td property="skos:definition">Verhouding van 1:3 of kleiner tussen de maximale hoogte van het BeheerDeel en de afmeting gemeten langs de steilste helling van het BeheerDeel.</td>
-                        <td property="skos:note">0</td>
+                        <td property="skos:definition">TODO</td>
+                        <td property="skos:note"></td>
                         <td property="skos:note">TOT_1_3</td>
                       </tr>
                     
-                      <tr id="TaludWaarde%3AVan%201%202%20En%20Steiler" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptschema/TaludWaarde#VAN_1_2_EN_STEILER">
+                      <tr id="Talud%20waarde%3A" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/VAN_1_3_TOT_1_2">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptschema/TaludWaarde#VAN_1_2_EN_STEILER" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptschema/TaludWaarde#VAN_1_2_EN_STEILER" data-placement="right">
-                            Van 1 2 En Steiler</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/VAN_1_3_TOT_1_2" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/VAN_1_3_TOT_1_2" data-placement="right">
+                            </a>
                           </code>
                         </td>
-                        <td property="skos:definition">Verhouding van 1:2 en groter tussen de maximale hoogte van het BeheerDeel en de afmeting gemeten langs de steilste helling van het BeheerDeel.</td>
-                        <td property="skos:note">0</td>
-                        <td property="skos:note">VAN_1_2_EN_STEILER</td>
+                        <td property="skos:definition">TODO</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">VAN_1_3_TOT_1_2</td>
                       </tr>
                     
-                      <tr id="TaludWaarde%3AVan%201%203%20Tot%201%202" typeof="rdfs:Property" resource="http://data.vlaanderen.be/id/conceptschema/TaludWaarde#VAN_1_3_TOT_1_2">
+                      <tr id="Talud%20waarde%3A" typeof="rdfs:Property" resource="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/VAN_1_2_EN_STEILER">
                         <td>
                           <code property="rdfs:label">
-                            <a href="http://data.vlaanderen.be/id/conceptschema/TaludWaarde#VAN_1_3_TOT_1_2" data-toggle="tooltip" data-content="http://data.vlaanderen.be/id/conceptschema/TaludWaarde#VAN_1_3_TOT_1_2" data-placement="right">
-                            Van 1 3 Tot 1 2</a>
+                            <a href="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/VAN_1_2_EN_STEILER" data-toggle="tooltip" data-content="https://data.vlaanderen.be/id/conceptscheme/TaludWaarde/VAN_1_2_EN_STEILER" data-placement="right">
+                            </a>
                           </code>
                         </td>
-                        <td property="skos:definition">Verhouding tussen 1:3 en 1:2 tussen de maximale hoogte van het BeheerDeel en de afmeting gemeten langs de steilste helling van het BeheerDeel.</td>
-                        <td property="skos:note">0</td>
-                        <td property="skos:note">VAN_1_3_TOT_1_2</td>
+                        <td property="skos:definition">TODO</td>
+                        <td property="skos:note"></td>
+                        <td property="skos:note">VAN_1_2_EN_STEILER</td>
                       </tr>
                     
                     </tbody>

--- a/doc/conceptscheme/ToestemmingStatus.ttl
+++ b/doc/conceptscheme/ToestemmingStatus.ttl
@@ -4,27 +4,30 @@
 <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus>
    a skos:ConceptScheme ;
    skos:definition "De status van de toestemming op een gegeven moment."@nl ;
-   rdfs:label "ToestemmingStatus"@nl .
+   skos:prefLabel "Toestemming status"@nl .
 
 <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus/toegelaten>
    a skos:Concept ;
-   rdfs:label "toegelaten"@nl ;
+   skos:prefLabel "toegelaten"@nl ;
    skos:definition "Het data subject verleende expliciet toestemming."@nl ;
    skos:notation "toegelaten"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus> .
 
 <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus/nietGekend>
    a skos:Concept ;
-   rdfs:label "nietGekend"@nl ;
+   skos:prefLabel "niet gekend"@nl ;
    skos:definition "De status van de toestemming is niet gekend, bijvoorbeeld na migratie van informatiesysteem of omdat geen informatie over de expliciete toestemming werd bijgehouden."@nl ;
    skos:note "In dit geval zal opnieuw expliciete toestemming aan het data subject moeten gevraagd worden."@nl ;
    skos:notation "nietGekend"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus> .
 
 <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus/geweigerd>
    a skos:Concept ;
-   rdfs:label "geweigerd"@nl ;
+   skos:prefLabel "geweigerd"@nl ;
    skos:definition "De toestemming werd expliciet geweigerd of ingetrokken door het data subject."@nl ;
    skos:notation "geweigerd"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus> .
 

--- a/doc/conceptscheme/ToestemmingStatus.ttl
+++ b/doc/conceptscheme/ToestemmingStatus.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/ToestemmingStatus>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "De status van de toestemming op een gegeven moment."@nl ;
    skos:prefLabel "Toestemming status"@nl .
 

--- a/doc/conceptscheme/Vervoersmiddelen.ttl
+++ b/doc/conceptscheme/Vervoersmiddelen.ttl
@@ -1,22 +1,24 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen>
+<https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen>
    a skos:ConceptScheme ;
    skos:definition "Types vervoersmidellen"@nl ;
-   rdfs:label "Vervoersmiddelen"@nl .
+   skos:prefLabel "Vervoersmiddelen"@nl .
 
-<http://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen#Fiets>
+<https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen/Fiets>
    a skos:Concept ;
-   rdfs:label "Fiets"@nl ;
+   skos:prefLabel "Fiets"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Fiets"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen> .
 
-<http://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen#Auto>
+<https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen/Auto>
    a skos:Concept ;
-   rdfs:label "Auto"@nl ;
+   skos:prefLabel "Auto"@nl ;
    skos:definition "TODO"@nl ;
    skos:notation "Auto"@nl ;
-   skos:inScheme <http://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen> .
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen> ;
+   skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen> .
 

--- a/doc/conceptscheme/Vervoersmiddelen.ttl
+++ b/doc/conceptscheme/Vervoersmiddelen.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Vervoersmiddelen>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Types vervoersmidellen"@nl ;
    skos:prefLabel "Vervoersmiddelen"@nl .
 

--- a/doc/conceptscheme/Verwerkingsgronden.ttl
+++ b/doc/conceptscheme/Verwerkingsgronden.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "De rechtsgrond voor de verwerkingsactiviteit."@nl ;
    skos:prefLabel "Verwerkingsgronden"@nl .
 

--- a/doc/conceptscheme/Verwerkingsgronden.ttl
+++ b/doc/conceptscheme/Verwerkingsgronden.ttl
@@ -4,47 +4,53 @@
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden>
    a skos:ConceptScheme ;
    skos:definition "De rechtsgrond voor de verwerkingsactiviteit."@nl ;
-   rdfs:label "Verwerkingsgronden"@nl .
+   skos:prefLabel "Verwerkingsgronden"@nl .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden/3977>
    a skos:Concept ;
-   rdfs:label "3977"@nl ;
+   skos:prefLabel "Toestemming betrokkene"@nl ;
    skos:definition "De betrokkene heeft toestemming gegeven voor de verwerking van zijn persoonsgegevens voor een of meer specifieke doeleinden (art.6.1a) AVG). Let op, de toestemming dient evenwel te voldoen aan de voorwaarden zoals bepaalt in art.7 AVG"@nl ;
    skos:notation "3977"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden/4688>
    a skos:Concept ;
-   rdfs:label "4688"@nl ;
+   skos:prefLabel "Noodzakelijk voor uitvoering van een overeenkomst"@nl ;
    skos:definition "De verwerking is noodzakelijk voor de uitvoering van een overeenkomst waarbij de betrokkene partij is, of om op verzoek van de betrokkene vóór de sluiting van een overeenkomst maatregelen te nemen (art.6.1b) AVG)"@nl ;
    skos:notation "4688"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden/9237>
    a skos:Concept ;
-   rdfs:label "9237"@nl ;
+   skos:prefLabel "Wettelijke verplichting"@nl ;
    skos:definition "De verwerking is noodzakelijk om te voldoen aan een wettelijke verplichting die op de verwerkingsverantwoordelijke rust (art.6.1c) AVG)"@nl ;
    skos:notation "9237"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden/9459>
    a skos:Concept ;
-   rdfs:label "9459"@nl ;
+   skos:prefLabel "Beschermen van vitale belangen van de betrokkene"@nl ;
    skos:definition "De verwerking is noodzakelijk om de vitale belangen van de betrokkene of van een andere natuurlijke persoon te beschermen (art.6.1d) AVG)"@nl ;
    skos:notation "9459"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden/3942>
    a skos:Concept ;
-   rdfs:label "3942"@nl ;
+   skos:prefLabel "Taak van algemeen belang of uitoefening van het openbaar gezag"@nl ;
    skos:definition "De verwerking is noodzakelijk voor de vervulling van een taak van algemeen belang of van een taak in het kader van de uitoefening van het openbaar gezag dat aan de verwerkingsverantwoordelijke is opgedragen (art.6.1e) AVG)"@nl ;
    skos:notation "3942"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden/1856>
    a skos:Concept ;
-   rdfs:label "1856"@nl ;
+   skos:prefLabel "Gerechtvaardigde belangen van de verwerkingsverantwoordelijke of van een derde"@nl ;
    skos:definition "De verwerking is noodzakelijk voor de behartiging van de gerechtvaardigde belangen van de verwerkingsverantwoordelijke of van een derde, behalve wanneer de belangen of de grondrechten en de fundamentele vrijheden van de betrokkene die tot bescherming van persoonsgegevens nopen, zwaarder wegen dan die belangen, met name wanneer de betrokkene een kind is (art.6.1f) AVG)"@nl ;
    skos:notation "1856"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingsgronden> .
 

--- a/doc/conceptscheme/Verwerkingstypes.ttl
+++ b/doc/conceptscheme/Verwerkingstypes.ttl
@@ -4,69 +4,77 @@
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes>
    a skos:ConceptScheme ;
    skos:definition "Types van gegevensverwerking."@nl ;
-   rdfs:label "Verwerkingstypes"@nl .
+   skos:prefLabel "Verwerkingstypes"@nl .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes/8916>
    a skos:Concept ;
-   rdfs:label "8916"@nl ;
+   skos:prefLabel "Normaal"@nl ;
    skos:definition "Normale gegevensverwerking. Geen van de andere types is van toepassing."@nl ;
    skos:notation "8916"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes/5690>
    a skos:Concept ;
-   rdfs:label "5690"@nl ;
-   skos:definition "Evaluatie of beoordeling van mensen waaronder profilering en het maken van prognoses 
-"@nl ;
+   skos:prefLabel "Evaluatie of beoordeling"@nl ;
+   skos:definition "Evaluatie of beoordeling van mensen waaronder profilering en het maken van prognoses"@nl ;
    skos:notation "5690"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes/9397>
    a skos:Concept ;
-   rdfs:label "9397"@nl ;
+   skos:prefLabel "Geautomatiseerde beslissingen"@nl ;
    skos:definition "Geautomatiseerde beslissingen met rechtsgevolgen of vergelijkbare wezenlijke gevolgen."@nl ;
    skos:notation "9397"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes/5043>
    a skos:Concept ;
-   rdfs:label "5043"@nl ;
+   skos:prefLabel "Stelselmatige monitoring"@nl ;
    skos:definition "Stelselmatige monitoring (betrokkene volgen, monitoren en controleren) (klank-, beeld- of video-opname)"@nl ;
    skos:notation "5043"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes/9136>
    a skos:Concept ;
-   rdfs:label "9136"@nl ;
+   skos:prefLabel "Grootschalige gegevensverwerkingen"@nl ;
    skos:definition "Grootschalige gegevensverwerkingen of verwerkingen die gevolgen hebben voor een groot aantal stakeholders"@nl ;
    skos:notation "9136"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes/6548>
    a skos:Concept ;
-   rdfs:label "6548"@nl ;
+   skos:prefLabel "Combinatie of koppeling van gegevensverzamelingen"@nl ;
    skos:definition "Combinatie of koppeling van gegevensverzamelingen die betrokkenen niet redelijkerwijs kunnen verwachten."@nl ;
    skos:notation "6548"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes/5314>
    a skos:Concept ;
-   rdfs:label "5314"@nl ;
+   skos:prefLabel "Uitsluiting"@nl ;
    skos:definition "Gegevensverwerking die tot gevolg heeft dat betrokkenen een recht niet kunnen uitoefenen, dat zij geen gebruik kunnen maken van een dienst of geen contract kunnen afsluiten."@nl ;
    skos:notation "5314"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes/6458>
    a skos:Concept ;
-   rdfs:label "6458"@nl ;
+   skos:prefLabel "Gebruik van nieuwe technologieën"@nl ;
    skos:definition "Gebruik van nieuwe technologieën of toepassing van technische en organisatorische middelen."@nl ;
    skos:notation "6458"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes/9508>
    a skos:Concept ;
-   rdfs:label "9508"@nl ;
+   skos:prefLabel "monitoring van openbaar toegankelijke ruimten"@nl ;
    skos:definition "Stelselmatige en grootschalige monitoring van openbaar toegankelijke ruimten."@nl ;
    skos:notation "9508"@nl ;
+   skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> .
 

--- a/doc/conceptscheme/Verwerkingstypes.ttl
+++ b/doc/conceptscheme/Verwerkingstypes.ttl
@@ -1,8 +1,10 @@
 @prefix skos:      <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:       <http://purl.org/dc/terms/> .
 @prefix rdfs:      <http://www.w3.org/2000/01/rdf-schema#> .
 
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes>
    a skos:ConceptScheme ;
+   dct:modified "2018-07-23" ;
    skos:definition "Types van gegevensverwerking."@nl ;
    skos:prefLabel "Verwerkingstypes"@nl .
 
@@ -17,7 +19,7 @@
 <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes/5690>
    a skos:Concept ;
    skos:prefLabel "Evaluatie of beoordeling"@nl ;
-   skos:definition "Evaluatie of beoordeling van mensen waaronder profilering en het maken van prognoses"@nl ;
+   skos:definition "Evaluatie of beoordeling van mensen waaronder profilering en het maken van prognoses."@nl ;
    skos:notation "5690"@nl ;
    skos:topConceptOf <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> ;
    skos:inScheme <https://data.vlaanderen.be/id/conceptscheme/Verwerkingstypes> .


### PR DESCRIPTION
Aanpassen SKOS notatie voor codelijsten:

- aanpassen van "#" naar "/" URI voor skos:Concepts
- toevoegen skos:prefLabel
- toevoegen van skos:topConceptOf
- toevoegen van dct:modified voor een skos:ConceptScheme

Aanpassing documentatie Openbaar Domein:

- Toevoegen deadline public review